### PR TITLE
Reference Encoding Cases

### DIFF
--- a/Sources/Typeform/Models/Reference.swift
+++ b/Sources/Typeform/Models/Reference.swift
@@ -2,6 +2,21 @@ import Foundation
 
 public struct Reference: Hashable, RawRepresentable, Codable {
     
+    /// Controls the behavior of `Reference` encoding.
+    ///
+    /// By default, `JSONEncoder` will encode the underlying `UUID` in all uppercase characters.
+    /// Since the **Typeform** api uses lowercased GUID for reference strings, the default encoding behavior is to match.
+    public enum ValueEncodingCase {
+        /// The system default behavior is used.
+        case automatic
+        /// The value will be encoded using only upper-case characters.
+        case uppercase
+        /// The value will be encoded using only lower-case characters.
+        case lowercase
+    }
+    
+    public static var valueEncodingCase: ValueEncodingCase = .lowercase
+    
     public var rawValue: UUID
     
     public var uuidString: String { rawValue.uuidString }
@@ -29,6 +44,13 @@ public struct Reference: Hashable, RawRepresentable, Codable {
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
-        try container.encode(rawValue)
+        switch Self.valueEncodingCase {
+        case .automatic:
+            try container.encode(rawValue)
+        case .uppercase:
+            try container.encode(rawValue.uuidString.uppercased())
+        case .lowercase:
+            try container.encode(rawValue.uuidString.lowercased())
+        }
     }
 }

--- a/Tests/TypeformTests/ResponsesTests.swift
+++ b/Tests/TypeformTests/ResponsesTests.swift
@@ -12,6 +12,26 @@ final class ResponsesTests: TypeformTests {
         label: "An update or follow-up on how you are feeling regarding an illness or injury that was discussed with a Specialty medical provider"
     )
     
+    /// Verify the `Reference.valueEncodingCase` options.
+    ///
+    /// - note: The double quote is correct; JSON fragment.
+    func testReferenceEncoding() throws {
+        Reference.valueEncodingCase = .automatic
+        var data = try TypeformTests.encoder.encode(visitReason)
+        var value = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertEqual(value, #""AEA7A268-64D4-4F16-920A-B9AFE317E3B6""#)
+        
+        Reference.valueEncodingCase = .uppercase
+        data = try TypeformTests.encoder.encode(visitReason)
+        value = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertEqual(value, #""AEA7A268-64D4-4F16-920A-B9AFE317E3B6""#)
+        
+        Reference.valueEncodingCase = .lowercase
+        data = try TypeformTests.encoder.encode(visitReason)
+        value = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertEqual(value, #""aea7a268-64d4-4f16-920a-b9afe317e3b6""#)
+    }
+    
     func testValidVisitReasonResponses() throws {
         responses[visitReason] = .choice(visitChoice)
         XCTAssertTrue(responses.validResponseValues(given: form.fields))


### PR DESCRIPTION
# Description

Now that `Reference` conforms to `Codable`, some unexpected behavior occurred. I had previously left the encoding of `Reference` and `ResponseValue` up to the implementing client. This was to combat the default system behavior of encoding `UUID` in all uppercase characters. To keep this implementation in sync with the rest of our Legacy system - as well as matching the Typeform api - the encoding of `Reference` will be in lower-cased characters. But an option has been put in place to make this behavior configurable.

