### PR TITLE
Deprecated Dates

### DIFF
--- a/Sources/Typeform/Schema/Form.swift
+++ b/Sources/Typeform/Schema/Form.swift
@@ -34,8 +34,11 @@ public struct Form: Hashable, Identifiable, Codable {
     public let hidden: [String]
     public let settings: Settings
     public let workspace: Workspace
+    @available(*, deprecated, message: "This is no longer in the API contract.")
     public let createdAt: Date
+    @available(*, deprecated, message: "This is no longer in the API contract.")
     public let publishedAt: Date
+    @available(*, deprecated, message: "This is no longer in the API contract.")
     public let lastUpdatedAt: Date
     public let welcomeScreens: [WelcomeScreen]
     public let endingScreens: [EndingScreen]
@@ -72,5 +75,24 @@ public struct Form: Hashable, Identifiable, Codable {
         self.lastUpdatedAt = lastUpdatedAt
         self.welcomeScreens = welcomeScreens
         self.endingScreens = endingScreens
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.type = try container.decode(Form.Kind.self, forKey: .type)
+        self.logic = try container.decode([Logic].self, forKey: .logic)
+        self.theme = try container.decode(Theme.self, forKey: .theme)
+        self.title = try container.decode(String.self, forKey: .title)
+        self.links = try container.decode(Links.self, forKey: .links)
+        self.fields = try container.decode([Field].self, forKey: .fields)
+        self.hidden = try container.decode([String].self, forKey: .hidden)
+        self.settings = try container.decode(Settings.self, forKey: .settings)
+        self.workspace = try container.decode(Workspace.self, forKey: .workspace)
+        self.createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date()
+        self.publishedAt = try container.decodeIfPresent(Date.self, forKey: .publishedAt) ?? Date()
+        self.lastUpdatedAt = try container.decodeIfPresent(Date.self, forKey: .lastUpdatedAt) ?? Date()
+        self.welcomeScreens = try container.decode([WelcomeScreen].self, forKey: .welcomeScreens)
+        self.endingScreens = try container.decode([EndingScreen].self, forKey: .endingScreens)
     }
 }


### PR DESCRIPTION
# Description

Recent queries of the Typeform API have shown the the `created_at`, `published_at` and `last_updated_at` keys are no longer returned in the results. So, these have been deprecated and will be removed in the future.

The `init(from: Decoder)` has been overridden to account for responses that do not have these values.

