### PR TITLE
Ending Screen Conclusion

### DIFF
--- a/Sources/Typeform/Schema/Form.swift
+++ b/Sources/Typeform/Schema/Form.swift
@@ -17,9 +17,6 @@ public struct Form: Hashable, Identifiable, Codable {
         case hidden
         case settings
         case workspace
-        case createdAt = "created_at"
-        case publishedAt = "published_at"
-        case lastUpdatedAt = "last_updated_at"
         case welcomeScreens = "welcome_screens"
         case endingScreens = "thankyou_screens"
     }
@@ -34,12 +31,6 @@ public struct Form: Hashable, Identifiable, Codable {
     public let hidden: [String]
     public let settings: Settings
     public let workspace: Workspace
-    @available(*, deprecated, message: "This is no longer in the API contract.")
-    public let createdAt: Date
-    @available(*, deprecated, message: "This is no longer in the API contract.")
-    public let publishedAt: Date
-    @available(*, deprecated, message: "This is no longer in the API contract.")
-    public let lastUpdatedAt: Date
     public let welcomeScreens: [WelcomeScreen]
     public let endingScreens: [EndingScreen]
     
@@ -54,9 +45,6 @@ public struct Form: Hashable, Identifiable, Codable {
         hidden: [String] = [],
         settings: Settings = Settings(),
         workspace: Workspace = Workspace(),
-        createdAt: Date = Date(),
-        publishedAt: Date = Date(),
-        lastUpdatedAt: Date = Date(),
         welcomeScreens: [WelcomeScreen] = [],
         endingScreens: [EndingScreen] = []
     ) {
@@ -70,9 +58,6 @@ public struct Form: Hashable, Identifiable, Codable {
         self.hidden = hidden
         self.settings = settings
         self.workspace = workspace
-        self.createdAt = createdAt
-        self.publishedAt = publishedAt
-        self.lastUpdatedAt = lastUpdatedAt
         self.welcomeScreens = welcomeScreens
         self.endingScreens = endingScreens
     }
@@ -89,9 +74,6 @@ public struct Form: Hashable, Identifiable, Codable {
         self.hidden = try container.decode([String].self, forKey: .hidden)
         self.settings = try container.decode(Settings.self, forKey: .settings)
         self.workspace = try container.decode(Workspace.self, forKey: .workspace)
-        self.createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date()
-        self.publishedAt = try container.decodeIfPresent(Date.self, forKey: .publishedAt) ?? Date()
-        self.lastUpdatedAt = try container.decodeIfPresent(Date.self, forKey: .lastUpdatedAt) ?? Date()
         self.welcomeScreens = try container.decode([WelcomeScreen].self, forKey: .welcomeScreens)
         self.endingScreens = try container.decode([EndingScreen].self, forKey: .endingScreens)
     }

--- a/Sources/TypeformUI/Conclusion.swift
+++ b/Sources/TypeformUI/Conclusion.swift
@@ -3,7 +3,7 @@ import Typeform
 /// The outcome of answering a specific `Form`
 public enum Conclusion {
     /// The `Form` was completed to a defined endpoint.
-    case completed(Responses)
+    case completed(Responses, EndingScreen)
     /// The `Form` was abandoned after the `WelcomeScreen` and before a `EndingScreen`.
     case abandoned(Responses)
     /// The `Form` was rejected due to invalid form logic & navigation.

--- a/Sources/TypeformUI/Structure/ScreenView.swift
+++ b/Sources/TypeformUI/Structure/ScreenView.swift
@@ -71,7 +71,7 @@ struct ScreenView<Header: View, Footer: View>: View {
                         
                         if !isWelcome {
                             Button {
-                                conclusion(.completed(responses))
+                                conclusion(.completed(responses, screen as! EndingScreen))
                             } label: {
                                 Text(settings.localization.finish)
                             }
@@ -93,7 +93,7 @@ struct ScreenView<Header: View, Footer: View>: View {
                     
                     if !isWelcome {
                         Button {
-                            conclusion(.completed(responses))
+                            conclusion(.completed(responses, screen as! EndingScreen))
                         } label: {
                             Text(settings.localization.finish)
                         }
@@ -110,7 +110,7 @@ struct ScreenView<Header: View, Footer: View>: View {
         .onAppear {
             next = try? form.next(from: .screen(screen), given: responses)
             if !isWelcome && settings.presentation.skipEndingScreen {
-                conclusion(.completed(responses))
+                conclusion(.completed(responses, screen as! EndingScreen))
             }
         }
         .toolbar {
@@ -132,7 +132,7 @@ struct ScreenView<Header: View, Footer: View>: View {
                     
                     if !isWelcome {
                         Button {
-                            conclusion(.completed(responses))
+                            conclusion(.completed(responses, screen as! EndingScreen))
                         } label: {
                             Text(settings.localization.finish)
                         }

--- a/Tests/TypeformTests/SchemaTests.swift
+++ b/Tests/TypeformTests/SchemaTests.swift
@@ -4,26 +4,15 @@ import XCTest
 final class SchemeTests: TypeformTests {
     
     func testEncodeForm() throws {
-        let form = Form(
-            createdAt: .distantPast,
-            publishedAt: .distantPast,
-            lastUpdatedAt: .distantPast
-        )
+        let form = Form()
         let data = try TypeformTests.prettyEncoder.encode(form)
         let json = try XCTUnwrap(String(data: data, encoding: .utf8))
-        
-        #if os(Linux)
-        let distantPast = "0001-12-30T00:00:00+00:00"
-        #else
-        let distantPast = "0001-01-01T00:00:00+00:00"
-        #endif
         
         XCTAssertEqual(json, """
         {
           "_links" : {
             "display" : "https:\\/\\/www.typeform.com"
           },
-          "created_at" : "\(distantPast)",
           "fields" : [
 
           ],
@@ -31,11 +20,9 @@ final class SchemeTests: TypeformTests {
 
           ],
           "id" : "",
-          "last_updated_at" : "\(distantPast)",
           "logic" : [
 
           ],
-          "published_at" : "\(distantPast)",
           "settings" : {
             "are_uploads_public" : false,
             "capabilities" : {


### PR DESCRIPTION
# Description

Updated UI `Conclusion` to include `EndingScreen`.
This will allow for knowledge of _which_ ending (i.e. Thank You) screen was reached as a result of responding to the form.

_Also, removed deprecated `Form` dates._