### PR TITLE
Pre-Loaded Responses

### DIFF
--- a/Sources/Typeform/Extensions/Form+Position.swift
+++ b/Sources/Typeform/Extensions/Form+Position.swift
@@ -4,7 +4,7 @@ public extension Form {
     /// When preloading responses for the form, the _first_ field may no longer be the one desired to be shown.
     ///
     /// - parameters:
-    ///   - skipWelcomeScreen: Flag indicated wether a 'Welcome Screen' should be skipped if present.
+    ///   - skipWelcomeScreen: Flag indicated whether a 'Welcome Screen' should be skipped if present.
     ///   - responses: Any responses that are already known when the form is first presented.
     /// - returns: The first `Position` to be presented.
     func firstPosition(skipWelcomeScreen: Bool, given responses: Responses) throws -> Position {
@@ -77,7 +77,7 @@ private extension Form {
     func nextPosition(from field: Field, group: Group?, given responses: Responses) throws -> Position {
         let currentPosition: Position = .field(field, group)
         
-        // Is a response required of current position?
+        // Is a response required of the current position?
         if responses.responseRequired(for: field) {
             throw TypeformError.noEntryForField
         }

--- a/Sources/Typeform/Extensions/Form+Position.swift
+++ b/Sources/Typeform/Extensions/Form+Position.swift
@@ -1,10 +1,33 @@
 public extension Form {
-    // swiftlint:disable cyclomatic_complexity
+    /// Determine the first `Position` that should be displayed given the provided `Responses`.
+    ///
+    /// When preloading responses for the form, the _first_ field may no longer be the one desired to be shown.
+    ///
+    /// - parameters:
+    ///   - skipWelcomeScreen: Flag indicated wether a 'Welcome Screen' should be skipped if present.
+    ///   - responses: Any responses that are already known when the form is first presented.
+    /// - returns: The first `Position` to be presented.
+    func firstPosition(skipWelcomeScreen: Bool, given responses: Responses) throws -> Position {
+        if let screen = firstScreen, !skipWelcomeScreen {
+            return .screen(screen)
+        }
+        
+        guard let field = fields.first else {
+            if let screen = defaultOrFirstEndingScreen {
+                return .screen(screen)
+            } else {
+                throw TypeformError.couldNotDetermineFirst
+            }
+        }
+        
+        return try next(from: .field(field), given: responses)
+    }
+     
     /// Determine the next `Field` or `Screen` given the provided `Responses`.
     ///
     /// - parameters:
-    ///   - position:
-    ///   - responses:
+    ///   - position: The current `Position` from which to determine the next field or screen to present.
+    ///   - responses: The current `Responses` gathered while interacting with the form.
     /// - returns: The next `Position`to be presented.
     /// - throws: `TypeformError`
     func next(from position: Position, given responses: Responses) throws -> Position {
@@ -23,82 +46,126 @@ public extension Form {
             
             throw TypeformError.couldNotDetermineNext(position)
         case .field(let field, let group):
-            let entry = responses[field.ref]
-            if let validations = field.validations, validations.required {
-                if entry == nil {
-                    throw TypeformError.noEntryForField
-                }
-            }
-            
-            // Is the `Field` of type `group`? Position at first question of sub-group.
-            if case .group(let properties) = field.properties {
-                guard let first = properties.fields.first else {
-                    throw TypeformError.couldNotDetermineNext(position)
-                }
+            var next: Position = .field(field, group)
+            do {
+                next = try nextPosition(from: field, group: group, given: responses)
+                var requiresResponse = false
                 
-                return .field(first, properties)
-            }
-            
-            // Is there specific `Logic` for the `Field`? Process it for actions
-            if let logic = logic.first(where: { $0.ref == field.ref }) {
-                if let action = logic.actions.first(where: { $0.condition.satisfied(given: responses) == true }) {
-                    switch action.details.to.type {
-                    case .field:
-                        if let position = parent(forFieldWithRef: action.details.to.value) {
-                            return position
+                while !requiresResponse {
+                    switch next {
+                    case .screen:
+                        requiresResponse = true
+                    case .field(let nextField, let nextGroup):
+                        if responses[nextField.ref] == nil {
+                            requiresResponse = true
+                        } else {
+                            next = try nextPosition(from: nextField, group: nextGroup, given: responses)
                         }
-                        
-                        throw TypeformError.couldNotDetermineNext(position)
-                    case .ending:
-                        if let next = endingScreens.first(where: { $0.ref == .ref(action.details.to.value) }) {
-                            return .screen(next)
-                        } else if let next = endingScreens.first(where: { $0.ref == .default }) {
-                            return .screen(next)
-                        }
-                        
-                        throw TypeformError.couldNotDetermineNext(position)
                     }
                 }
-            }
-            
-            // Are we already in a `Group`? What's the next `Field`?
-            if let group = group {
-                guard let index = group.fields.firstIndex(of: field) else {
-                    throw TypeformError.couldNotDetermineNext(position)
-                }
                 
-                let nextIndex = index + 1
-                if nextIndex < group.fields.count {
-                    return .field(group.fields[nextIndex], group)
-                }
+                return next
+            } catch TypeformError.noEntryForField {
+                return next
             }
-            
-            // If the `Group` is complete, what is the next `Field`?
-            if let ancestorPosition = ancestor(forFieldWithRef: field.ref) {
-                guard case .field(let ancestor, _) = ancestorPosition else {
-                    throw TypeformError.couldNotDetermineNext(position)
-                }
-                
-                guard let index = fields.firstIndex(of: ancestor) else {
-                    throw TypeformError.couldNotDetermineNext(position)
-                }
-                
-                let nextIndex = index + 1
-                if nextIndex < fields.count {
-                    return .field(fields[nextIndex])
-                }
-            }
-            
-            // If the `Field` has no `Logic and is not in a `Group`... what is the next `Field`?
-            if let index = fields.firstIndex(of: field) {
-                let nextIndex = index + 1
-                if nextIndex < fields.count {
-                    return .field(fields[nextIndex])
-                }
-            }
-            
-            throw TypeformError.couldNotDetermineNext(position)
         }
     }
+}
+
+private extension Form {
+    // swiftlint:disable cyclomatic_complexity
+    func nextPosition(from field: Field, group: Group?, given responses: Responses) throws -> Position {
+        let currentPosition: Position = .field(field, group)
+        
+        // Is a response required of current position?
+        if responses.responseRequired(for: field) {
+            throw TypeformError.noEntryForField
+        }
+        
+        // Is this `Field` of type `group`?
+        if case .group(let properties) = field.properties {
+            guard let firstGroupField = properties.fields.first else {
+                throw TypeformError.couldNotDetermineNext(currentPosition)
+            }
+            
+            return .field(firstGroupField, properties)
+        }
+        
+        // Is there `Logic` that applies to this `Field`?
+        if let logic = logic.first(where: { $0.ref == field.ref }) {
+            if let action = logic.actions.first(where: { $0.condition.satisfied(given: responses) == true }) {
+                switch action.details.to.type {
+                case .field:
+                    if let position = parent(forFieldWithRef: action.details.to.value) {
+                        return position
+                    }
+                    
+                    throw TypeformError.couldNotDetermineNext(currentPosition)
+                case .ending:
+                    if let screen = endingScreens.first(where: { $0.ref == .ref(action.details.to.value) }) {
+                        return .screen(screen)
+                    } else if let screen = endingScreens.first(where: { $0.ref == .default }) {
+                        return .screen(screen)
+                    }
+                    
+                    throw TypeformError.couldNotDetermineNext(currentPosition)
+                }
+            }
+        }
+        
+        // Are we already in a `Group`?
+        if let group = group {
+            // Is there a next `Field`
+            guard let fieldIndex = group.fields.firstIndex(of: field) else {
+                throw TypeformError.couldNotDetermineNext(currentPosition)
+            }
+            
+            if (fieldIndex + 1) < group.fields.count {
+                return .field(group.fields[fieldIndex + 1], group)
+            }
+            
+            // Is the `Group` complete?
+            if let ancestorPosition = ancestor(forFieldWithRef: field.ref) {
+                guard case .field(let ancestor, _) = ancestorPosition else {
+                    throw TypeformError.couldNotDetermineNext(currentPosition)
+                }
+                
+                guard let ancestorIndex = fields.firstIndex(of: ancestor) else {
+                    throw TypeformError.couldNotDetermineNext(currentPosition)
+                }
+                
+                if (ancestorIndex + 1) < fields.count {
+                    return .field(fields[ancestorIndex + 1])
+                }
+            }
+        }
+        
+        // Is there a next `Field`?
+        if let index = fields.firstIndex(of: field) {
+            if (index + 1) < fields.count {
+                return .field(fields[index + 1])
+            }
+        }
+        
+        throw TypeformError.couldNotDetermineNext(currentPosition)
+    }
     // swiftlint:enable cyclomatic_complexity
+}
+
+private extension Responses {
+    func responseRequired(for field: Field) -> Bool {
+        guard let validations = field.validations else {
+            return false
+        }
+        
+        guard validations.required else {
+            return false
+        }
+        
+        guard self[field.ref] == nil else {
+            return false
+        }
+        
+        return true
+    }
 }

--- a/Sources/Typeform/Models/TypeformError.swift
+++ b/Sources/Typeform/Models/TypeformError.swift
@@ -5,7 +5,6 @@ public enum TypeformError: Error {
     case noActionForChoice
     case noEntryForField
     case noLogicForField
-    case endOfForm
     
     case varCollectionMissingInvalidField
     case varCollectionMissingInvalidValue

--- a/Sources/Typeform/Models/TypeformError.swift
+++ b/Sources/Typeform/Models/TypeformError.swift
@@ -1,9 +1,11 @@
 public enum TypeformError: Error {
+    case couldNotDetermineFirst
     case couldNotDetermineNext(_ position: Position)
     case multipleLogicForField
     case noActionForChoice
     case noEntryForField
     case noLogicForField
+    case endOfForm
     
     case varCollectionMissingInvalidField
     case varCollectionMissingInvalidValue

--- a/Sources/TypeformUI/Components/ChoiceButtonStyle.swift
+++ b/Sources/TypeformUI/Components/ChoiceButtonStyle.swift
@@ -75,10 +75,9 @@ struct ChoiceButtonStyle_Previews: PreviewProvider {
     static var previews: some View {
         ScrollView {
             MultipleChoiceView(
-                reference: .multipleChoice_One,
+                state: .constant(ResponseState()),
                 properties: .preview_One,
-                settings: Settings(),
-                responses: .constant([:])
+                settings: Settings()
             )
             .padding()
         }
@@ -86,10 +85,9 @@ struct ChoiceButtonStyle_Previews: PreviewProvider {
         
         ScrollView {
             MultipleChoiceView(
-                reference: .multipleChoice_Many,
+                state: .constant(ResponseState()),
                 properties: .preview_Many,
-                settings: Settings(),
-                responses: .constant([:])
+                settings: Settings()
             )
             .padding()
         }

--- a/Sources/TypeformUI/Fields/DateStampView.swift
+++ b/Sources/TypeformUI/Fields/DateStampView.swift
@@ -80,9 +80,9 @@ struct DateStampView: View {
         }
         
         if let validations = self.validations, validations.required {
-            state.passesValidation = state.response != nil
+            state.invalid = state.response == nil
         } else {
-            state.passesValidation = true
+            state.invalid = false
         }
         
         self.state.wrappedValue = state

--- a/Sources/TypeformUI/Fields/DropdownView.swift
+++ b/Sources/TypeformUI/Fields/DropdownView.swift
@@ -66,9 +66,9 @@ struct DropdownView: View {
         }
         
         if let validations = self.validations, validations.required {
-            state.passesValidation = selected != nil
+            state.invalid = selected == nil
         } else {
-            state.passesValidation = true
+            state.invalid = false
         }
         
         self.state.wrappedValue = state

--- a/Sources/TypeformUI/Fields/DropdownView.swift
+++ b/Sources/TypeformUI/Fields/DropdownView.swift
@@ -5,12 +5,10 @@ import TypeformPreview
 
 struct DropdownView: View {
     
-    let reference: Reference
-    let properties: Dropdown
-    let settings: Settings
-    var responses: Binding<Responses>
+    var state: Binding<ResponseState>
+    var properties: Dropdown
+    var settings: Settings
     var validations: Validations?
-    var validated: Binding<Bool>?
     
     @State private var selected: Choice?
     
@@ -40,48 +38,49 @@ struct DropdownView: View {
         .frame(maxWidth: .infinity, alignment: .trailing)
         .fieldStyle(settings: settings)
         .onAppear {
-            let entry = responses.wrappedValue[reference]
-            switch entry {
-            case .choice(let choice):
-                selected = choice
-            default:
-                selected = nil
-            }
-            
-            determineValidity()
+            registerState()
         }
-        .onChange(of: selected) { newValue in
-            if let choice = newValue {
-                responses.wrappedValue[reference] = .choice(choice)
-            } else {
-                responses.wrappedValue[reference] = nil
-            }
-            
-            determineValidity()
+        .onChange(of: selected) { _ in
+            updateState()
         }
     }
     
-    private func determineValidity() {
-        guard let validated = self.validated else {
-            return
+    private func registerState() {
+        switch state.wrappedValue.response {
+        case .choice(let choice):
+            selected = choice
+        default:
+            selected = nil
         }
         
-        guard let validations = validations, validations.required else {
-            validated.wrappedValue = true
-            return
+        updateState()
+    }
+    
+    private func updateState() {
+        var state = self.state.wrappedValue
+        
+        if let choice = selected {
+            state.response = .choice(choice)
+        } else {
+            state.response = nil
         }
         
-        validated.wrappedValue = selected != nil
+        if let validations = self.validations, validations.required {
+            state.passesValidation = selected != nil
+        } else {
+            state.passesValidation = true
+        }
+        
+        self.state.wrappedValue = state
     }
 }
 
 struct DropdownView_Previews: PreviewProvider {
     static var previews: some View {
         DropdownView(
-            reference: .dropdown,
+            state: .constant(ResponseState()),
             properties: .preview,
-            settings: Settings(),
-            responses: .constant([:])
+            settings: Settings()
         )
     }
 }

--- a/Sources/TypeformUI/Fields/LongTextView.swift
+++ b/Sources/TypeformUI/Fields/LongTextView.swift
@@ -79,9 +79,9 @@ struct LongTextView: View {
         }
         
         if let validations = self.validations, validations.required {
-            state.passesValidation = !value.isEmpty
+            state.invalid = value.isEmpty
         } else {
-            state.passesValidation = true
+            state.invalid = false
         }
         
         self.state.wrappedValue = state

--- a/Sources/TypeformUI/Fields/LongTextView.swift
+++ b/Sources/TypeformUI/Fields/LongTextView.swift
@@ -5,12 +5,10 @@ import TypeformPreview
 
 struct LongTextView: View {
     
-    let reference: Reference
-    let properties: LongText
-    let settings: Settings
-    var responses: Binding<Responses>
+    var state: Binding<ResponseState>
+    var properties: LongText
+    var settings: Settings
     var validations: Validations?
-    var validated: Binding<Bool>?
     var focused: FocusState<Bool>.Binding
     
     @State private var value: String = ""
@@ -53,38 +51,40 @@ struct LongTextView: View {
             )
         }
         .onAppear {
-            let entry = responses.wrappedValue[reference]
-            switch entry {
-            case .string(let string):
-                value = string
-            default:
-                value = ""
-            }
-            
-            determineValidity()
+            registerState()
         }
-        .onChange(of: value) { newValue in
-            if newValue.isEmpty {
-                responses.wrappedValue[reference] = nil
-            } else {
-                responses.wrappedValue[reference] = .string(newValue)
-            }
-            
-            determineValidity()
+        .onChange(of: value) { _ in
+            updateState()
         }
     }
     
-    private func determineValidity() {
-        guard let validated = self.validated else {
-            return
+    private func registerState() {
+        switch state.wrappedValue.response {
+        case .string(let string):
+            value = string
+        default:
+            value = ""
         }
         
-        guard let validations = validations, validations.required else {
-            validated.wrappedValue = true
-            return
+        updateState()
+    }
+    
+    private func updateState() {
+        var state = self.state.wrappedValue
+        
+        if value.isEmpty {
+            state.response = nil
+        } else {
+            state.response = .string(value)
         }
         
-        validated.wrappedValue = !value.isEmpty
+        if let validations = self.validations, validations.required {
+            state.passesValidation = !value.isEmpty
+        } else {
+            state.passesValidation = true
+        }
+        
+        self.state.wrappedValue = state
     }
 }
 
@@ -92,10 +92,9 @@ struct LongTextView_Previews: PreviewProvider {
     @FocusState static var focused: Bool
     static var previews: some View {
         LongTextView(
-            reference: .longText,
+            state: .constant(ResponseState()),
             properties: .preview,
             settings: Settings(),
-            responses: .constant([:]),
             focused: $focused
         )
     }

--- a/Sources/TypeformUI/Fields/MultipleChoiceView.swift
+++ b/Sources/TypeformUI/Fields/MultipleChoiceView.swift
@@ -94,12 +94,12 @@ struct MultipleChoiceView: View {
         
         if let validations = self.validations, validations.required {
             if properties.allow_multiple_selection {
-                state.passesValidation = !selections.isEmpty
+                state.invalid = selections.isEmpty
             } else {
-                state.passesValidation = selections.count == 1
+                state.invalid = selections.count != 1
             }
         } else {
-            state.passesValidation = true
+            state.invalid = false
         }
         
         self.state.wrappedValue = state

--- a/Sources/TypeformUI/Fields/NumberView.swift
+++ b/Sources/TypeformUI/Fields/NumberView.swift
@@ -51,9 +51,9 @@ struct NumberView: View {
         }
         
         if let validations = self.validations, validations.required {
-            state.passesValidation = value != nil
+            state.invalid = value == nil
         } else {
-            state.passesValidation = true
+            state.invalid = false
         }
         
         self.state.wrappedValue = state

--- a/Sources/TypeformUI/Fields/NumberView.swift
+++ b/Sources/TypeformUI/Fields/NumberView.swift
@@ -5,12 +5,10 @@ import TypeformPreview
 
 struct NumberView: View {
     
-    let reference: Reference
-    let properties: Number
-    let settings: Settings
-    var responses: Binding<Responses>
+    var state: Binding<ResponseState>
+    var properties: Number
+    var settings: Settings
     var validations: Validations?
-    var validated: Binding<Bool>?
     
     @State private var value: Int?
     
@@ -25,48 +23,49 @@ struct NumberView: View {
                 .fieldStyle(settings: settings)
         }
         .onAppear {
-            let entry = responses.wrappedValue[reference]
-            switch entry {
-            case .int(let int):
-                value = int
-            default:
-                value = nil
-            }
-            
-            determineValidity()
+            registerState()
         }
-        .onChange(of: value) { newValue in
-            if let response = newValue {
-                responses.wrappedValue[reference] = .int(response)
-            } else {
-                responses.wrappedValue[reference] = nil
-            }
-            
-            determineValidity()
+        .onChange(of: value) { _ in
+            updateState()
         }
     }
     
-    private func determineValidity() {
-        guard let validated = self.validated else {
-            return
+    private func registerState() {
+        switch state.wrappedValue.response {
+        case .int(let int):
+            value = int
+        default:
+            value = nil
         }
         
-        guard let validations = validations, validations.required else {
-            validated.wrappedValue = true
-            return
+        updateState()
+    }
+    
+    private func updateState() {
+        var state = self.state.wrappedValue
+        
+        if let response = value {
+            state.response = .int(response)
+        } else {
+            state.response = nil
         }
         
-        validated.wrappedValue = value != nil
+        if let validations = self.validations, validations.required {
+            state.passesValidation = value != nil
+        } else {
+            state.passesValidation = true
+        }
+        
+        self.state.wrappedValue = state
     }
 }
 
 struct NumberView_Previews: PreviewProvider {
     static var previews: some View {
         NumberView(
-            reference: .number,
+            state: .constant(ResponseState()),
             properties: .preview,
-            settings: Settings(),
-            responses: .constant([:])
+            settings: Settings()
         )
     }
 }

--- a/Sources/TypeformUI/Fields/RatingView.swift
+++ b/Sources/TypeformUI/Fields/RatingView.swift
@@ -101,9 +101,9 @@ struct RatingView: View {
         }
         
         if let validations = self.validations, validations.required {
-            state.passesValidation = value != nil
+            state.invalid = value == nil
         } else {
-            state.passesValidation = true
+            state.invalid = false
         }
         
         self.state.wrappedValue = state

--- a/Sources/TypeformUI/Fields/RatingView.swift
+++ b/Sources/TypeformUI/Fields/RatingView.swift
@@ -5,12 +5,10 @@ import TypeformPreview
 
 struct RatingView: View {
     
-    let reference: Reference
-    let properties: Rating
-    let settings: Settings
-    var responses: Binding<Responses>
+    var state: Binding<ResponseState>
+    var properties: Rating
+    var settings: Settings
     var validations: Validations?
-    var validated: Binding<Bool>?
     
     @State private var value: Int?
     
@@ -71,24 +69,10 @@ struct RatingView: View {
             }
         }
         .onAppear {
-            let entry = responses.wrappedValue[reference]
-            switch entry {
-            case .int(let int):
-                value = int
-            default:
-                value = 0
-            }
-            
-            determineValidity()
+            registerState()
         }
-        .onChange(of: value) { newValue in
-            if let response = newValue {
-                responses.wrappedValue[reference] = .int(response)
-            } else {
-                responses.wrappedValue[reference] = nil
-            }
-            
-            determineValidity()
+        .onChange(of: value) { _ in
+            updateState()
         }
     }
     
@@ -96,27 +80,42 @@ struct RatingView: View {
         (value ?? 0) >= step ? settings.rating.selectedForegroundColor : settings.rating.unselectedForegroundColor
     }
     
-    private func determineValidity() {
-        guard let validated = self.validated else {
-            return
+    private func registerState() {
+        switch state.wrappedValue.response {
+        case .int(let int):
+            value = int
+        default:
+            value = nil
         }
         
-        guard let validations = validations, validations.required else {
-            validated.wrappedValue = true
-            return
+        updateState()
+    }
+    
+    private func updateState() {
+        var state = self.state.wrappedValue
+        
+        if let response = value {
+            state.response = .int(response)
+        } else {
+            state.response = nil
         }
         
-        validated.wrappedValue = value != nil
+        if let validations = self.validations, validations.required {
+            state.passesValidation = value != nil
+        } else {
+            state.passesValidation = true
+        }
+        
+        self.state.wrappedValue = state
     }
 }
 
 struct RatingView_Previews: PreviewProvider {
     static var previews: some View {
         RatingView(
-            reference: .rating,
+            state: .constant(ResponseState()),
             properties: .preview,
-            settings: Settings(),
-            responses: .constant([:])
+            settings: Settings()
         )
     }
 }

--- a/Sources/TypeformUI/Fields/ShortTextView.swift
+++ b/Sources/TypeformUI/Fields/ShortTextView.swift
@@ -5,12 +5,10 @@ import TypeformPreview
 
 struct ShortTextView: View {
     
-    let reference: Reference
-    let properties: ShortText
-    let settings: Settings
-    var responses: Binding<Responses>
+    var state: Binding<ResponseState>
+    var properties: ShortText
+    var settings: Settings
     var validations: Validations?
-    var validated: Binding<Bool>?
     var focused: FocusState<Bool>.Binding
     
     @State private var value: String = ""
@@ -27,38 +25,40 @@ struct ShortTextView: View {
                 .focused(focused)
         }
         .onAppear {
-            let entry = responses.wrappedValue[reference]
-            switch entry {
-            case .string(let string):
-                value = string
-            default:
-                value = ""
-            }
-            
-            determineValidity()
+            registerState()
         }
-        .onChange(of: value) { newValue in
-            if newValue.isEmpty {
-                responses.wrappedValue[reference] = nil
-            } else {
-                responses.wrappedValue[reference] = .string(newValue)
-            }
-            
-            determineValidity()
+        .onChange(of: value) { _ in
+            updateState()
         }
     }
     
-    private func determineValidity() {
-        guard let validated = self.validated else {
-            return
+    private func registerState() {
+        switch state.wrappedValue.response {
+        case .string(let string):
+            value = string
+        default:
+            value = ""
         }
         
-        guard let validations = validations, validations.required else {
-            validated.wrappedValue = true
-            return
+        updateState()
+    }
+    
+    private func updateState() {
+        var state = self.state.wrappedValue
+        
+        if value.isEmpty {
+            state.response = nil
+        } else {
+            state.response = .string(value)
         }
         
-        validated.wrappedValue = !value.isEmpty
+        if let validations = self.validations, validations.required {
+            state.passesValidation = !value.isEmpty
+        } else {
+            state.passesValidation = true
+        }
+        
+        self.state.wrappedValue = state
     }
 }
 
@@ -66,10 +66,9 @@ struct ShortTextView_Previews: PreviewProvider {
     @FocusState static var focused: Bool
     static var previews: some View {
         ShortTextView(
-            reference: .shortText,
+            state: .constant(ResponseState()),
             properties: .preview,
             settings: Settings(),
-            responses: .constant([:]),
             focused: $focused
         )
     }

--- a/Sources/TypeformUI/Fields/ShortTextView.swift
+++ b/Sources/TypeformUI/Fields/ShortTextView.swift
@@ -53,9 +53,9 @@ struct ShortTextView: View {
         }
         
         if let validations = self.validations, validations.required {
-            state.passesValidation = !value.isEmpty
+            state.invalid = value.isEmpty
         } else {
-            state.passesValidation = true
+            state.invalid = false
         }
         
         self.state.wrappedValue = state

--- a/Sources/TypeformUI/Fields/StatementView.swift
+++ b/Sources/TypeformUI/Fields/StatementView.swift
@@ -5,12 +5,8 @@ import TypeformPreview
 
 struct StatementView: View {
     
-    let reference: Reference
-    let properties: Statement
-    let settings: Settings
-    var responses: Binding<Responses>
-    var validations: Validations?
-    var validated: Binding<Bool>?
+    var properties: Statement
+    var settings: Settings
     
     var body: some View {
         VStack(alignment: .leading, spacing: settings.presentation.descriptionContentVerticalSpacing) {
@@ -20,32 +16,14 @@ struct StatementView: View {
                     .foregroundColor(settings.typography.captionColor)
             }
         }
-        .onAppear {
-            determineValidity()
-        }
-    }
-    
-    private func determineValidity() {
-        guard let validated = self.validated else {
-            return
-        }
-        
-        guard let validations = validations, validations.required else {
-            validated.wrappedValue = true
-            return
-        }
-        
-        validated.wrappedValue = true
     }
 }
 
 struct StatementView_Previews: PreviewProvider {
     static var previews: some View {
         StatementView(
-            reference: .statement,
             properties: .preview,
-            settings: Settings(),
-            responses: .constant([:])
+            settings: Settings()
         )
     }
 }

--- a/Sources/TypeformUI/Fields/YesNoView.swift
+++ b/Sources/TypeformUI/Fields/YesNoView.swift
@@ -5,12 +5,10 @@ import TypeformPreview
 
 struct YesNoView: View {
     
-    let reference: Reference
-    let properties: YesNo
-    let settings: Settings
-    var responses: Binding<Responses>
+    var state: Binding<ResponseState>
+    var properties: YesNo
+    var settings: Settings
     var validations: Validations?
-    var validated: Binding<Bool>?
     
     @State private var selected: Bool?
     
@@ -49,48 +47,49 @@ struct YesNoView: View {
             }
         }
         .onAppear {
-            let entry = responses.wrappedValue[reference]
-            switch entry {
-            case .bool(let bool):
-                selected = bool
-            default:
-                selected = nil
-            }
-            
-            determineValidity()
+            registerState()
         }
-        .onChange(of: selected) { newValue in
-            if let response = newValue {
-                responses.wrappedValue[reference] = .bool(response)
-            } else {
-                responses.wrappedValue[reference] = nil
-            }
-            
-            determineValidity()
+        .onChange(of: selected) { _ in
+            updateState()
         }
     }
     
-    private func determineValidity() {
-        guard let validated = self.validated else {
-            return
+    private func registerState() {
+        switch state.wrappedValue.response {
+        case .bool(let bool):
+            selected = bool
+        default:
+            selected = nil
         }
         
-        guard let validations = validations, validations.required else {
-            validated.wrappedValue = true
-            return
+        updateState()
+    }
+    
+    private func updateState() {
+        var state = self.state.wrappedValue
+        
+        if let response = selected {
+            state.response = .bool(response)
+        } else {
+            state.response = nil
         }
         
-        validated.wrappedValue = selected != nil
+        if let validations = self.validations, validations.required {
+            state.passesValidation = selected != nil
+        } else {
+            state.passesValidation = true
+        }
+        
+        self.state.wrappedValue = state
     }
 }
 
 struct YesNoView_Previews: PreviewProvider {
     static var previews: some View {
         YesNoView(
-            reference: .yesNo,
+            state: .constant(ResponseState()),
             properties: .preview,
-            settings: Settings(),
-            responses: .constant([:])
+            settings: Settings()
         )
     }
 }

--- a/Sources/TypeformUI/Fields/YesNoView.swift
+++ b/Sources/TypeformUI/Fields/YesNoView.swift
@@ -75,9 +75,9 @@ struct YesNoView: View {
         }
         
         if let validations = self.validations, validations.required {
-            state.passesValidation = selected != nil
+            state.invalid = selected == nil
         } else {
-            state.passesValidation = true
+            state.invalid = false
         }
         
         self.state.wrappedValue = state

--- a/Sources/TypeformUI/ResponseState.swift
+++ b/Sources/TypeformUI/ResponseState.swift
@@ -1,16 +1,23 @@
 import Typeform
 
+/// A collective representation of a single `Responses` element.
 struct ResponseState: Equatable {
+    /// The `ResponseValue` for the given `Field` being presented.
     var response: ResponseValue?
-    var passesValidation: Bool
+    /// Indication of whether validation indicates a failure.
+    var invalid: Bool
     
-    init(response: ResponseValue? = nil, passesValidation: Bool = false) {
+    init(response: ResponseValue? = nil, invalid: Bool = true) {
         self.response = response
-        self.passesValidation = passesValidation
+        self.invalid = invalid
     }
     
-    init(field: Field, responses: Responses) {
+    init(for field: Field, given responses: Responses) {
         self.response = responses[field.ref]
-        self.passesValidation = false
+        if case .statement = field.properties {
+            self.invalid = false
+        } else {
+            self.invalid = true
+        }
     }
 }

--- a/Sources/TypeformUI/ResponseState.swift
+++ b/Sources/TypeformUI/ResponseState.swift
@@ -1,0 +1,16 @@
+import Typeform
+
+struct ResponseState: Equatable {
+    var response: ResponseValue?
+    var passesValidation: Bool
+    
+    init(response: ResponseValue? = nil, passesValidation: Bool = false) {
+        self.response = response
+        self.passesValidation = passesValidation
+    }
+    
+    init(field: Field, responses: Responses) {
+        self.response = responses[field.ref]
+        self.passesValidation = false
+    }
+}

--- a/Sources/TypeformUI/Structure/FieldView.swift
+++ b/Sources/TypeformUI/Structure/FieldView.swift
@@ -47,7 +47,7 @@ struct FieldView<Header: View, Footer: View>: View {
         self.conclusion = conclusion
         self.header = header
         self.footer = footer
-        _responseState = .init(initialValue: ResponseState(field: field, responses: responses))
+        _responseState = .init(initialValue: ResponseState(for: field, given: responses))
         _responses = .init(initialValue: responses)
     }
     
@@ -236,7 +236,7 @@ struct FieldView<Header: View, Footer: View>: View {
         } label: {
             Text(nextTitle)
         }
-        .disabled(next == nil && !responseState.passesValidation)
+        .disabled(next == nil || responseState.invalid)
     }
 }
 
@@ -257,7 +257,7 @@ extension FieldView where Footer == EmptyView {
         self.conclusion = conclusion
         self.header = header
         self.footer = { Footer() }
-        _responseState = .init(initialValue: ResponseState(field: field, responses: responses))
+        _responseState = .init(initialValue: ResponseState(for: field, given: responses))
         _responses = .init(initialValue: responses)
     }
 }
@@ -279,7 +279,7 @@ extension FieldView where Header == EmptyView {
         self.conclusion = conclusion
         self.header = { Header() }
         self.footer = footer
-        _responseState = .init(initialValue: ResponseState(field: field, responses: responses))
+        _responseState = .init(initialValue: ResponseState(for: field, given: responses))
         _responses = .init(initialValue: responses)
     }
 }
@@ -300,7 +300,7 @@ extension FieldView where Footer == EmptyView, Header == EmptyView {
         self.conclusion = conclusion
         self.header = { Header() }
         self.footer = { Footer() }
-        _responseState = .init(initialValue: ResponseState(field: field, responses: responses))
+        _responseState = .init(initialValue: ResponseState(for: field, given: responses))
         _responses = .init(initialValue: responses)
     }
 }

--- a/Sources/TypeformUI/Structure/RejectedView.swift
+++ b/Sources/TypeformUI/Structure/RejectedView.swift
@@ -5,9 +5,9 @@ import TypeformPreview
 
 struct RejectedView: View {
     
-    @Binding var responses: Responses
     let form: Typeform.Form
     let settings: Settings
+    let responses: Responses
     let conclusion: (Conclusion) -> Void
     
     var body: some View {
@@ -66,9 +66,9 @@ struct RejectedView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             RejectedView(
-                responses: .constant([:]),
                 form: .medicalIntake23,
                 settings: Settings(),
+                responses: [:],
                 conclusion: { _ in }
             )
         }

--- a/Sources/TypeformUI/Structure/ScreenView.swift
+++ b/Sources/TypeformUI/Structure/ScreenView.swift
@@ -6,10 +6,10 @@ import TypeformPreview
 
 struct ScreenView<Header: View, Footer: View>: View {
     
-    @Binding var responses: Responses
     let form: Typeform.Form
     let screen: any Screen
     let settings: Settings
+    let responses: Responses
     let conclusion: (Conclusion) -> Void
     let header: () -> Header
     let footer: () -> Footer
@@ -30,18 +30,18 @@ struct ScreenView<Header: View, Footer: View>: View {
     }
     
     init(
-        responses: Binding<Responses>,
         form: Typeform.Form,
         screen: any Screen,
         settings: Settings,
+        responses: Responses,
         conclusion: @escaping (Conclusion) -> Void,
         @ViewBuilder header: @escaping () -> Header,
         @ViewBuilder footer: @escaping () -> Footer
     ) {
-        _responses = responses
         self.form = form
         self.screen = screen
         self.settings = settings
+        self.responses = responses
         self.conclusion = conclusion
         self.header = header
         self.footer = footer
@@ -148,21 +148,21 @@ struct ScreenView<Header: View, Footer: View>: View {
             switch next {
             case .field(let field, let group):
                 FieldView(
-                    responses: $responses,
                     form: form,
                     field: field,
                     group: group,
                     settings: settings,
+                    responses: responses,
                     conclusion: conclusion,
                     header: header,
                     footer: footer
                 )
             case .screen(let screen):
                 ScreenView(
-                    responses: $responses,
                     form: form,
                     screen: screen,
                     settings: settings,
+                    responses: responses,
                     conclusion: conclusion,
                     header: header,
                     footer: footer
@@ -176,17 +176,17 @@ struct ScreenView<Header: View, Footer: View>: View {
 
 extension ScreenView where Footer == EmptyView {
     init(
-        responses: Binding<Responses>,
         form: Typeform.Form,
         screen: any Screen,
         settings: Settings,
+        responses: Responses,
         conclusion: @escaping (Conclusion) -> Void,
         @ViewBuilder header: @escaping () -> Header
     ) {
-        _responses = responses
         self.form = form
         self.screen = screen
         self.settings = settings
+        self.responses = responses
         self.conclusion = conclusion
         self.header = header
         self.footer = { Footer() }
@@ -195,17 +195,17 @@ extension ScreenView where Footer == EmptyView {
 
 extension ScreenView where Header == EmptyView {
     init(
-        responses: Binding<Responses>,
         form: Typeform.Form,
         screen: any Screen,
         settings: Settings,
+        responses: Responses,
         conclusion: @escaping (Conclusion) -> Void,
         @ViewBuilder footer: @escaping () -> Footer
     ) {
-        _responses = responses
         self.form = form
         self.screen = screen
         self.settings = settings
+        self.responses = responses
         self.conclusion = conclusion
         self.header = { Header() }
         self.footer = footer
@@ -214,46 +214,46 @@ extension ScreenView where Header == EmptyView {
 
 extension ScreenView where Footer == EmptyView, Header == EmptyView {
     init(
-        responses: Binding<Responses>,
         form: Typeform.Form,
         screen: any Screen,
         settings: Settings,
+        responses: Responses,
         conclusion: @escaping (Conclusion) -> Void
     ) {
-        _responses = responses
         self.form = form
         self.screen = screen
         self.settings = settings
+        self.responses = responses
         self.conclusion = conclusion
         self.header = { Header() }
         self.footer = { Footer() }
     }
 }
 
-struct ScreenView_Previews: PreviewProvider {
-    static var previews: some View {
-        NavigationView {
-            ScreenView(
-                responses: .constant([:]),
-                form: .medicalIntake23,
-                screen: WelcomeScreen.preview,
-                settings: Settings(),
-                conclusion: { _ in }
-            )
-        }
-        .previewDisplayName("Welcome Screen")
-        
-        NavigationView {
-            ScreenView(
-                responses: .constant([:]),
-                form: .medicalIntake23,
-                screen: EndingScreen.preview,
-                settings: Settings(),
-                conclusion: { _ in }
-            )
-        }
-        .previewDisplayName("Thank You Screen")
+#if swift(>=5.9)
+#Preview("Welcome Screen") {
+    NavigationView {
+        ScreenView(
+            form: .medicalIntake23,
+            screen: WelcomeScreen.preview,
+            settings: Settings(),
+            responses: [:],
+            conclusion: { _ in }
+        )
     }
 }
+
+#Preview("Thank You Screen") {
+    NavigationView {
+        ScreenView(
+            form: .medicalIntake23,
+            screen: EndingScreen.preview,
+            settings: Settings(),
+            responses: [:],
+            conclusion: { _ in }
+        )
+    }
+}
+#endif
 #endif
 // swiftlint:enable force_cast

--- a/Tests/TypeformTests/MedicalIntake35Tests.swift
+++ b/Tests/TypeformTests/MedicalIntake35Tests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import Typeform
 @testable import TypeformPreview
 
-class MedicalIntake35Tests : TypeformTests {
+class MedicalIntake35Tests: TypeformTests {
     
     override var jsonResource: String { "MedicalIntake35" }
     
@@ -54,7 +54,7 @@ class MedicalIntake35Tests : TypeformTests {
         
         let currentGroupField = try XCTUnwrap(form.field(withRef: Reference(string: "reason-for-visit-acute-intro")))
         guard case .group(let currentGroup) = currentGroupField.properties else {
-            XCTFail()
+            XCTFail("Unexpected Properties")
             return
         }
         let currentField = try XCTUnwrap(form.field(withRef: Reference(string: "reason-for-visit-acute-symptoms-other")))
@@ -62,7 +62,7 @@ class MedicalIntake35Tests : TypeformTests {
         
         let next = try form.next(from: .field(currentField, currentGroup), given: responses)
         guard case .field(let field, let group) = next else {
-            XCTFail()
+            XCTFail("Unexpected Position")
             return
         }
 

--- a/Tests/TypeformTests/PreLoadedResponsesTests.swift
+++ b/Tests/TypeformTests/PreLoadedResponsesTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+@testable import Typeform
+@testable import TypeformPreview
+
+final class PreLoadedResponsesTests: TypeformTests {
+    
+    override var jsonResource: String { "MedicalIntake26" }
+    
+    func testNotSkippingWelcomeEmptyResponses() throws {
+        let responses: Responses = [:]
+        let position = try form.firstPosition(skipWelcomeScreen: false, given: responses)
+        guard case let .screen(screen) = position else {
+            XCTFail("Unexpected Position")
+            return
+        }
+        
+        guard let welcomeScreen = screen as? WelcomeScreen else {
+            XCTFail("Unexpected Screen")
+            return
+        }
+        
+        XCTAssertEqual(welcomeScreen.id, "NGCT4k03bG7W")
+    }
+    
+    func testNotSkippingWelcomeFirstFieldResponses() throws {
+        let responses: Responses = [
+            .uuid(UUID(uuidString: "508ea9df-177c-4cda-8371-8f7cc1bc60a2")!): .choice(
+                Choice(
+                    id: "eSMBTpzeqJYQ",
+                    ref: .string("65fd22c3-32ec-4c92-b194-5aef3a10fe60"),
+                    label: "Alabama"
+                )
+            )
+        ]
+        
+        let position = try form.firstPosition(skipWelcomeScreen: false, given: responses)
+        guard case let .screen(screen) = position else {
+            XCTFail("Unexpected Position")
+            return
+        }
+        
+        guard let welcomeScreen = screen as? WelcomeScreen else {
+            XCTFail("Unexpected Screen")
+            return
+        }
+        
+        XCTAssertEqual(welcomeScreen.id, "NGCT4k03bG7W")
+    }
+    
+    func testSkippingWelcomeEmptyResponses() throws {
+        let responses: Responses = [:]
+        
+        let position = try form.firstPosition(skipWelcomeScreen: true, given: responses)
+        guard case let .field(field, group) = position else {
+            XCTFail("Unexpected Position")
+            return
+        }
+        
+        XCTAssertEqual(field.id, "89Ofk9JaI4M1")
+        XCTAssertNil(group)
+    }
+    
+    func testSkippingWelcomeFirstFieldResponses() throws {
+        let responses: Responses = [
+            .uuid(UUID(uuidString: "508ea9df-177c-4cda-8371-8f7cc1bc60a2")!): .choice(
+                Choice(
+                    id: "Rh7fHLNn7tRV",
+                    ref: .uuid(UUID(uuidString: "aa028c7c-ce34-428f-8563-35bce5201dc1")!),
+                    label: "Minnesota"
+                )
+            )
+        ]
+        
+        let position = try form.firstPosition(skipWelcomeScreen: true, given: responses)
+        guard case let .field(field, group) = position else {
+            XCTFail("Unexpected Position")
+            return
+        }
+        
+        XCTAssertEqual(field.id, "0mMHJCj4JoPr")
+        XCTAssertNil(group)
+    }
+    
+    /// There is a 'Statement' field after the first response, and before the second response. What comes after that field?
+    func testSkippingWelcomePostStatementResponses() throws {
+        let responses: Responses = [
+            .uuid(UUID(uuidString: "508ea9df-177c-4cda-8371-8f7cc1bc60a2")!): .choice(
+                Choice(
+                    id: "Rh7fHLNn7tRV",
+                    ref: .uuid(UUID(uuidString: "aa028c7c-ce34-428f-8563-35bce5201dc1")!),
+                    label: "Minnesota"
+                )
+            ),
+            .uuid(UUID(uuidString: "4915db69-55ca-4a00-b57e-893d7ea3e761")!): .choice(
+                Choice(
+                    id: "QQP6V2LnuOBK",
+                    ref: .uuid(UUID(uuidString: "a66c1065-4e4f-46fc-8a26-794cc46a59f9")!),
+                    label: "Adult, 18-64 years of age"
+                )
+            )
+        ]
+        
+        var position = try form.firstPosition(skipWelcomeScreen: true, given: responses)
+        guard case let .field(field, group) = position else {
+            XCTFail("Unexpected Position")
+            return
+        }
+        
+        XCTAssertEqual(field.id, "0mMHJCj4JoPr")
+        XCTAssertNil(group)
+        
+        position = try form.next(from: position, given: responses)
+        
+        guard case let .field(nextField, nextGroup) = position else {
+            XCTFail("Unexpected Position")
+            return
+        }
+        
+        XCTAssertEqual(nextField.id, "0QSfTuGGV8W5")
+        XCTAssertNil(nextGroup)
+    }
+}


### PR DESCRIPTION
# Description

Updates the library with support for pre-loaded responses. While determining the _first_ & _next_ `Position` (I.e. question to answer), the current responses will be checked. If an answer already exists, then the question will be skipped. The final `Conclusion` from a `Form` will always include _all_ responses.

## New/Updated Features

Some changes to how UI state management were also made. The entire _current_ response state is passed into the next view, meaning that each view will always have a consistent representation of the state at that time, leading to fewer unintended changes. Also added is a `ResponseState` representation the collects state changes from each question view, reducing the number of callbacks to manage..

Internal Reference: PATM-895