### PR TITLE
Opinion Scale Styling

### DIFF
--- a/Sources/TypeformUI/Components/IntermittentChoiceButtonStyle.swift
+++ b/Sources/TypeformUI/Components/IntermittentChoiceButtonStyle.swift
@@ -27,15 +27,27 @@ struct IntermittentChoiceButtonStyle: ButtonStyle {
     }
     
     private var backgroundColor: Color {
-        selected ? settings.interaction.selectedBackgroundColor : settings.interaction.unselectedBackgroundColor
+        if style == nil {
+            selected ? settings.rating.selectedBackgroundColor : settings.rating.unselectedBackgroundColor
+        } else {
+            selected ? settings.interaction.selectedBackgroundColor : settings.interaction.unselectedBackgroundColor
+        }
     }
     
     private var strokeColor: Color {
-        selected ? settings.interaction.selectedStrokeColor : settings.interaction.unselectedStrokeColor
+        if style == nil {
+            selected ? settings.rating.selectedStrokeColor : settings.rating.unselectedStrokeColor
+        } else {
+            selected ? settings.interaction.selectedStrokeColor : settings.interaction.unselectedStrokeColor
+        }
     }
     
     private var strokeWidth: Double {
-        selected ? settings.interaction.selectedStrokeWidth : settings.interaction.unselectedStrokeWidth
+        if style == nil {
+            selected ? settings.rating.selectedStrokeWidth : settings.rating.unselectedStrokeWidth
+        } else {
+            selected ? settings.interaction.selectedStrokeWidth : settings.interaction.unselectedStrokeWidth
+        }
     }
     
     private var shape: RoundedRectangle {

--- a/Sources/TypeformUI/Components/IntermittentChoiceButtonStyle.swift
+++ b/Sources/TypeformUI/Components/IntermittentChoiceButtonStyle.swift
@@ -43,10 +43,18 @@ struct IntermittentChoiceButtonStyle: ButtonStyle {
     }
     
     private var strokeWidth: Double {
-        if style == nil {
+        if style == .none {
             selected ? settings.rating.selectedStrokeWidth : settings.rating.unselectedStrokeWidth
         } else {
             selected ? settings.interaction.selectedStrokeWidth : settings.interaction.unselectedStrokeWidth
+        }
+    }
+    
+    private var foregroundColor: Color {
+        if style == .none {
+            selected ? settings.rating.selectedForegroundColor : settings.rating.unselectedForegroundColor
+        } else {
+            settings.typography.bodyColor
         }
     }
     
@@ -91,6 +99,7 @@ struct IntermittentChoiceButtonStyle: ButtonStyle {
             }
             
             configuration.label
+                .foregroundColor(foregroundColor)
         }
         .padding(.vertical, settings.interaction.contentVerticalInset)
         .padding(.horizontal, settings.interaction.contentHorizontalInset)

--- a/Sources/TypeformUI/Fields/OpinionScaleView.swift
+++ b/Sources/TypeformUI/Fields/OpinionScaleView.swift
@@ -12,26 +12,23 @@ struct OpinionScaleView: View {
     
     @State private var value: Int?
     
-    private var range: Range<Int> {
-        let start = properties.start_at_one ? 1 : 0
-        let end = properties.start_at_one ? properties.steps : properties.steps - 1
-        return Range(start...end)
-    }
-    
-    private var grid: [GridItem] {
-        (0..<6).map { _ in GridItem(.flexible()) }
-    }
+    private var start: Int { properties.start_at_one ? 1 : 0 }
+    private var end: Int { properties.start_at_one ? properties.steps : properties.steps - 1 }
+    private var range: Range<Int> { Range(start...end) }
+    private var grid: [GridItem] { (0..<6).map { _ in GridItem(.flexible()) } }
+    private var leadingLabel: String { String(format: "%d: %@", start, properties.labels.leading) }
+    private var trailingLabel: String { String(format: "%d: %@", end, properties.labels.trailing) }
     
     var body: some View {
         VStack(alignment: .leading, spacing: settings.presentation.descriptionContentVerticalSpacing) {
             HStack(alignment: .top) {
-                Text(properties.labels.leading)
+                Text(leadingLabel)
                     .font(settings.typography.captionFont)
                     .foregroundColor(settings.typography.captionColor)
                 
                 Spacer()
                 
-                Text(properties.labels.trailing)
+                Text(trailingLabel)
                     .font(settings.typography.captionFont)
                     .foregroundColor(settings.typography.captionColor)
             }

--- a/Sources/TypeformUI/Settings.swift
+++ b/Sources/TypeformUI/Settings.swift
@@ -163,9 +163,11 @@ public struct Settings {
         public var unselectedBackgroundColor: Color
         public var unselectedStrokeColor: Color
         public var unselectedStrokeWidth: Double
+        public var unselectedForegroundColor: Color
         public var selectedBackgroundColor: Color
         public var selectedStrokeColor: Color
         public var selectedStrokeWidth: Double
+        public var selectedForegroundColor: Color
         public var contentVerticalInset: Double
         public var contentHorizontalInset: Double
         public var contentCornerRadius: Double
@@ -174,9 +176,11 @@ public struct Settings {
             unselectedBackgroundColor: Color = .blue.opacity(0.2),
             unselectedStrokeColor: Color = .blue.opacity(0.5),
             unselectedStrokeWidth: Double = 1.0,
+            unselectedForegroundColor: Color = .white,
             selectedBackgroundColor: Color = .blue.opacity(0.5),
             selectedStrokeColor: Color = .blue.opacity(0.8),
             selectedStrokeWidth: Double = 2.0,
+            selectedForegroundColor: Color = .blue,
             contentVerticalInset: Double = 15.0,
             contentHorizontalInset: Double = 10.0,
             contentCornerRadius: Double = 6.0
@@ -184,9 +188,11 @@ public struct Settings {
             self.unselectedBackgroundColor = unselectedBackgroundColor
             self.unselectedStrokeColor = unselectedStrokeColor
             self.unselectedStrokeWidth = unselectedStrokeWidth
+            self.unselectedForegroundColor = unselectedForegroundColor
             self.selectedBackgroundColor = selectedBackgroundColor
             self.selectedStrokeColor = selectedStrokeColor
             self.selectedStrokeWidth = selectedStrokeWidth
+            self.selectedForegroundColor = selectedForegroundColor
             self.contentVerticalInset = contentVerticalInset
             self.contentHorizontalInset = contentHorizontalInset
             self.contentCornerRadius = contentCornerRadius

--- a/Sources/TypeformUI/Settings.swift
+++ b/Sources/TypeformUI/Settings.swift
@@ -241,14 +241,32 @@ public struct Settings {
     }
     
     public struct Rating {
+        public var unselectedBackgroundColor: Color
+        public var unselectedStrokeColor: Color
+        public var unselectedStrokeWidth: Double
         public var unselectedForegroundColor: Color
+        public var selectedBackgroundColor: Color
+        public var selectedStrokeColor: Color
+        public var selectedStrokeWidth: Double
         public var selectedForegroundColor: Color
         
         public init(
+            unselectedBackgroundColor: Color = .blue.opacity(0.3),
+            unselectedStrokeColor: Color = .blue.opacity(0.5),
+            unselectedStrokeWidth: Double = 1.0,
             unselectedForegroundColor: Color = .black,
+            selectedBackgroundColor: Color = .blue.opacity(0.3),
+            selectedStrokeColor: Color = .blue.opacity(0.9),
+            selectedStrokeWidth: Double = 2.0,
             selectedForegroundColor: Color = .blue
         ) {
+            self.unselectedBackgroundColor = unselectedBackgroundColor
+            self.unselectedStrokeColor = unselectedStrokeColor
+            self.unselectedStrokeWidth = unselectedStrokeWidth
             self.unselectedForegroundColor = unselectedForegroundColor
+            self.selectedBackgroundColor = selectedBackgroundColor
+            self.selectedStrokeColor = selectedStrokeColor
+            self.selectedStrokeWidth = selectedStrokeWidth
             self.selectedForegroundColor = selectedForegroundColor
         }
     }


### PR DESCRIPTION
# Description

The `OpinionScale` buttons sometimes need a different styling that the radio/checkbox options stemming from no extra indications of selection status. This update adds support for defining additional styling information as well as add the numerical prefixes to the opinion scale labels.

Internal Reference: PATM-933

