### PR TITLE
Improved Condition Handling

### DIFF
--- a/Sources/Typeform/Extensions/Condition+Validation.swift
+++ b/Sources/Typeform/Extensions/Condition+Validation.swift
@@ -1,5 +1,9 @@
 extension Condition {
     func satisfied(given responses: Responses) -> Bool? {
+        if case .always = op {
+            return true
+        }
+        
         let satisfied: [Bool]
         
         switch parameters {
@@ -7,10 +11,6 @@ extension Condition {
             satisfied = vars.compactMatch(given: responses, op: op)
         case .conditions(let conditions):
             satisfied = conditions.compactMap { $0.satisfied(given: responses) }
-        }
-        
-        if case .always = op {
-            return true
         }
         
         guard !satisfied.isEmpty else {
@@ -27,8 +27,8 @@ extension Condition {
         case .isNot:
             return !satisfied.contains(true)
         default:
-            print("Unexpected Condition.Op \(#function) \(#fileID) \(#line)")
-            return nil
+            // Equatable - [Var].compactMatch(given:op:)
+            return !satisfied.contains(false)
         }
     }
 }

--- a/Sources/Typeform/Extensions/Condition+Validation.swift
+++ b/Sources/Typeform/Extensions/Condition+Validation.swift
@@ -1,5 +1,5 @@
 extension Condition {
-    func satisfied(given responses: Responses) -> Bool? {
+    func satisfied(given responses: Responses) -> Bool {
         if case .always = op {
             return true
         }
@@ -10,7 +10,7 @@ extension Condition {
         case .vars(let vars):
             satisfied = vars.compactMatch(given: responses, op: op)
         case .conditions(let conditions):
-            satisfied = conditions.compactMap { $0.satisfied(given: responses) }
+            satisfied = conditions.map { $0.satisfied(given: responses) }
         }
         
         guard !satisfied.isEmpty else {

--- a/Sources/Typeform/Extensions/Form+Position.swift
+++ b/Sources/Typeform/Extensions/Form+Position.swift
@@ -97,7 +97,7 @@ private extension Form {
         
         // Is there `Logic` that applies to this `Field`?
         if let logic = logic.first(where: { $0.ref == field.ref }) {
-            if let action = logic.actions.first(where: { $0.condition.satisfied(given: responses) == true }) {
+            if let action = logic.actions.first(where: { $0.condition.satisfied(given: responses) }) {
                 switch action.details.to.type {
                 case .field:
                     if let position = parent(forFieldWithRef: action.details.to.value) {

--- a/Sources/TypeformUI/Fields/NumberView.swift
+++ b/Sources/TypeformUI/Fields/NumberView.swift
@@ -20,6 +20,7 @@ struct NumberView: View {
             }
             
             TextField("", value: $value, format: .number)
+                .keyboardType(.numberPad)
                 .fieldStyle(settings: settings)
         }
         .onAppear {

--- a/Sources/TypeformUI/Fields/NumberView.swift
+++ b/Sources/TypeformUI/Fields/NumberView.swift
@@ -20,7 +20,9 @@ struct NumberView: View {
             }
             
             TextField("", value: $value, format: .number)
+                #if os(iOS) || os(tvOS)
                 .keyboardType(.numberPad)
+                #endif
                 .fieldStyle(settings: settings)
         }
         .onAppear {

--- a/Tests/TypeformTests/HealthHistoryFormTests.swift
+++ b/Tests/TypeformTests/HealthHistoryFormTests.swift
@@ -9,4 +9,28 @@ final class HealthHistoryFormTests: TypeformTests {
     func testDecoding() throws {
         XCTAssertEqual(form.id, "dmsX77W1")
     }
+    
+    func testMinorImmunization() throws {
+        let responses: Responses = [
+            .string("health-history-form-completed"): .bool(false),
+            .string("patient-age"): .int(17),
+            .string("sex-assigned-at-birth"): .choice(
+                Choice(id: "gYxjsy4loTDH", ref: .string("sex-assigned-at-birth-answer-male"), label: "Male")
+            ),
+            .string("medications-usage"): .bool(false),
+            .string("medication-allergies"): .bool(false),
+            .string("surgeries"): .bool(false),
+            .string("family-medical-history"): .string(""),
+        ]
+        
+        let lastField = try XCTUnwrap(form.field(withRef: .string("family-medical-history")))
+        let position = Position.field(lastField, nil)
+        let next = try form.next(from: position, given: responses)
+        guard case .field(let field, let group) = next else {
+            throw TypeformError.couldNotDetermineNext(position)
+        }
+        
+        XCTAssertEqual(field.ref, .string("minor-immunization-status"))
+        XCTAssertNil(group)
+    }
 }


### PR DESCRIPTION
# Description

The condition satisfaction logic was slightly off. In place of returning `nil` for a condition that had multiple `Var`s, it should be checking that vars were satisfied or not.

Internal Reference: PATM-937

