### PR TITLE
Optional Capabilities

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Package Resolution
       run: swift package resolve
@@ -42,7 +42,7 @@ jobs:
       run: xcrun llvm-cov export -format="lcov" .build/debug/${{ env.PACKAGE_NAME }}PackageTests.xctest/Contents/MacOS/${{ env.PACKAGE_NAME }}PackageTests -instr-profile .build/debug/codecov/default.profdata > build/reports/coverage.lcov
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: matrix.os == 'macos-latest'
       with:
         name: test-results
@@ -52,13 +52,13 @@ jobs:
         retention-days: 7
 
     - name: Publish Test Results
-      uses: EnricoMi/publish-unit-test-result-action/composite@v2
+      uses: EnricoMi/publish-unit-test-result-action/macos@v2
       if: matrix.os == 'macos-latest'
       with:
         files: build/reports/junit.xml
 
     - name: Publish Code Coverage
-      uses: vebr/jest-lcov-reporter@v0.2.1
+      uses: lifeart/jest-lcov-reporter@v0.4.0
       if: matrix.os == 'macos-latest'
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/Sources/Typeform/Schema/Settings.swift
+++ b/Sources/Typeform/Schema/Settings.swift
@@ -25,10 +25,10 @@ public struct Settings: Hashable, Codable {
             }
         }
         
-        public let e2e_encryption: EndToEndEncryption
+        public let e2e_encryption: EndToEndEncryption?
         
         public init(
-            e2e_encryption: EndToEndEncryption = .init()
+            e2e_encryption: EndToEndEncryption? = nil
         ) {
             self.e2e_encryption = e2e_encryption
         }
@@ -38,7 +38,7 @@ public struct Settings: Hashable, Codable {
     public let is_trial: Bool
     public let language: String
     public let is_public: Bool
-    public let capabilities: Capabilities
+    public let capabilities: Capabilities?
     public let progress_bar: String
     public let hide_navigation: Bool
     public let show_progress_bar: Bool
@@ -55,7 +55,7 @@ public struct Settings: Hashable, Codable {
         is_trial: Bool = false,
         language: String = "",
         is_public: Bool = false,
-        capabilities: Capabilities = .init(),
+        capabilities: Capabilities? = nil,
         progress_bar: String = "",
         hide_navigation: Bool = false,
         show_progress_bar: Bool = false,

--- a/Tests/TypeformTests/SchemaTests.swift
+++ b/Tests/TypeformTests/SchemaTests.swift
@@ -22,12 +22,6 @@ final class SchemeTests: TypeformTests {
           ],
           "settings" : {
             "are_uploads_public" : false,
-            "capabilities" : {
-              "e2e_encryption" : {
-                "enabled" : false,
-                "modifiable" : false
-              }
-            },
             "hide_navigation" : false,
             "is_public" : false,
             "is_trial" : false,


### PR DESCRIPTION
# Description

Removes the requirement to supply `Capabilities` as part of the `Settings` structure. This value doesn't seem to appear in the latest version of the API documents for retrieving forms.

Internal Reference: PATM-1052

