### PR TITLE
File Upload

### DIFF
--- a/Example/ContentView.swift
+++ b/Example/ContentView.swift
@@ -42,9 +42,9 @@ struct ContentView: View {
                         )
                         .autocorrectionDisabled(true)
                         #if canImport(UIKit)
-                        .textInputAutocapitalization(.none)
+                            .textInputAutocapitalization(.none)
                         #endif
-                        .focused($focus)
+                            .focused($focus)
 
                         Menu("Recent") {
                             ForEach(recent, id: \.self) { item in

--- a/Example/ContentView.swift
+++ b/Example/ContentView.swift
@@ -41,7 +41,9 @@ struct ContentView: View {
                             text: $formId
                         )
                         .autocorrectionDisabled(true)
+                        #if canImport(UIKit)
                         .textInputAutocapitalization(.none)
+                        #endif
                         .focused($focus)
 
                         Menu("Recent") {

--- a/Example/Example.entitlements
+++ b/Example/Example.entitlements
@@ -2,9 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.security.app-sandbox</key>
-    <true/>
-    <key>com.apple.security.files.user-selected.read-only</key>
-    <true/>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>

--- a/Example/ResponsesView.swift
+++ b/Example/ResponsesView.swift
@@ -49,6 +49,8 @@ struct ResponseValueView: View {
                 Text(int.formatted())
             case .string(let string):
                 Text(string)
+            case .upload(let upload):
+                Text(upload.mimeType)
             }
         } else {
             EmptyView()

--- a/README.MD
+++ b/README.MD
@@ -83,14 +83,20 @@ struct MyView: View {
 All of the _structural_ components are supported: Welcome Screen, Ending, Statement, and Question Group. Learn more about Typeform [Question Types](https://www.typeform.com/help/a/question-types-360051789692/?attribution_user_id=1dbdf7d8-4d28-44f6-8536-d95cf65b0311). The currently supported types are:
 
 * Date
-* Short Text
-* Long Text
-* Number
-* Rating
-* Multiple Choice
-* Yes/No
 * Dropdown
+* File Upload
+* Number
+* Long Text
+* Multiple Choice
 * Opinion Scale
+* Rating
+* Short Text
+* Yes/No
+
+### File Upload
+
+* File uploads are only supported on `UIKit` environments (iOS/iPad OS) at this time.
+* Only Image Files and PDFs are selectable. 
 
 ## Customization
 

--- a/Sources/Typeform/Extensions/Responses+Validation.swift
+++ b/Sources/Typeform/Extensions/Responses+Validation.swift
@@ -32,6 +32,10 @@ public extension Responses {
                 guard case .choice = value else {
                     return key
                 }
+            case .fileUpload:
+                guard case .upload = value else {
+                    return key
+                }
             case .group:
                 return key
             case .longText:

--- a/Sources/Typeform/Models/ResponseValue.swift
+++ b/Sources/Typeform/Models/ResponseValue.swift
@@ -7,4 +7,5 @@ public enum ResponseValue: Equatable {
     case date(Date)
     case int(Int)
     case string(String)
+    case upload(Upload)
 }

--- a/Sources/Typeform/Models/TypeformError.swift
+++ b/Sources/Typeform/Models/TypeformError.swift
@@ -10,4 +10,8 @@ public enum TypeformError: Error {
     case varCollectionMissingInvalidValue
     case responseTypeMismatch(Any.Type)
     case unexpectedOperation(Op)
+
+    case fileUploadSelection
+    case fileUploadData
+    case fileUploadSecurity
 }

--- a/Sources/Typeform/Models/Upload.swift
+++ b/Sources/Typeform/Models/Upload.swift
@@ -13,14 +13,17 @@ public struct Upload: Equatable {
     public let bytes: Data
     public let path: Path
     public let mimeType: String
+    public let fileName: String
 
     public init(
         bytes: Data,
         path: Path,
-        mimeType: String
+        mimeType: String,
+        fileName: String
     ) {
         self.bytes = bytes
         self.path = path
         self.mimeType = mimeType
+        self.fileName = fileName
     }
 }

--- a/Sources/Typeform/Models/Upload.swift
+++ b/Sources/Typeform/Models/Upload.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public struct Upload: Equatable {
+
+    public enum Path: String, Identifiable {
+        case camera
+        case photoLibrary
+        case documents
+
+        public var id: String { rawValue }
+    }
+
+    public let bytes: Data
+    public let path: Path
+    public let mimeType: String
+
+    public init(
+        bytes: Data,
+        path: Path,
+        mimeType: String
+    ) {
+        self.bytes = bytes
+        self.path = path
+        self.mimeType = mimeType
+    }
+}

--- a/Sources/Typeform/Schema/Field.swift
+++ b/Sources/Typeform/Schema/Field.swift
@@ -5,20 +5,22 @@ public struct Field: Hashable, Identifiable, Codable {
     public enum Kind: String, Codable {
         case date
         case dropdown
+        case fileUpload = "file_upload"
         case group
-        case long_text
-        case multiple_choice
+        case longText = "long_text"
+        case multipleChoice = "multiple_choice"
         case number
-        case opinion_scale
+        case opinionScale = "opinion_scale"
         case rating
-        case short_text
+        case shortText = "short_text"
         case statement
-        case yes_no
+        case yesNo = "yes_no"
     }
 
     public enum Properties: Hashable, Codable {
         case date(DateStamp)
         case dropdown(Dropdown)
+        case fileUpload(FileUpload)
         case group(Group)
         case longText(LongText)
         case multipleChoice(MultipleChoice)
@@ -32,7 +34,8 @@ public struct Field: Hashable, Identifiable, Codable {
         public var description: String? {
             switch self {
             case .date(let value): value.description
-            case .dropdown: nil
+            case .dropdown(let value): value.description
+            case .fileUpload(let value): value.description
             case .group: nil
             case .longText(let value): value.description
             case .multipleChoice(let value): value.description
@@ -67,7 +70,7 @@ public struct Field: Hashable, Identifiable, Codable {
     public init(
         id: String = "",
         ref: Reference = Reference(),
-        type: Kind = .yes_no,
+        type: Kind = .yesNo,
         title: String = "",
         properties: Properties = .yesNo(YesNo()),
         validations: Validations? = nil,
@@ -97,31 +100,34 @@ public struct Field: Hashable, Identifiable, Codable {
         case .dropdown:
             let dropdown = try container.decode(Dropdown.self, forKey: .properties)
             properties = .dropdown(dropdown)
+        case .fileUpload:
+            let fileUpload = try container.decode(FileUpload.self, forKey: .properties)
+            properties = .fileUpload(fileUpload)
         case .group:
             let group = try container.decode(Group.self, forKey: .properties)
             properties = .group(group)
-        case .long_text:
+        case .longText:
             let longText = try container.decode(LongText.self, forKey: .properties)
             properties = .longText(longText)
-        case .multiple_choice:
+        case .multipleChoice:
             let multipleChoice = try container.decode(MultipleChoice.self, forKey: .properties)
             properties = .multipleChoice(multipleChoice)
         case .number:
             let number = try container.decode(Number.self, forKey: .properties)
             properties = .number(number)
-        case .opinion_scale:
+        case .opinionScale:
             let optionScale = try container.decode(OpinionScale.self, forKey: .properties)
             properties = .opinionScale(optionScale)
         case .rating:
             let rating = try container.decode(Rating.self, forKey: .properties)
             properties = .rating(rating)
-        case .short_text:
+        case .shortText:
             let shortText = try container.decode(ShortText.self, forKey: .properties)
             properties = .shortText(shortText)
         case .statement:
             let statement = try container.decode(Statement.self, forKey: .properties)
             properties = .statement(statement)
-        case .yes_no:
+        case .yesNo:
             let yesNo = try container.decode(YesNo.self, forKey: .properties)
             properties = .yesNo(yesNo)
         }
@@ -140,6 +146,8 @@ public struct Field: Hashable, Identifiable, Codable {
             try container.encode(dateStamp, forKey: .properties)
         case .dropdown(let dropdown):
             try container.encode(dropdown, forKey: .properties)
+        case .fileUpload(let fileUpload):
+            try container.encode(fileUpload, forKey: .properties)
         case .group(let group):
             try container.encode(group, forKey: .properties)
         case .longText(let longText):
@@ -160,4 +168,19 @@ public struct Field: Hashable, Identifiable, Codable {
             try container.encode(yesNo, forKey: .properties)
         }
     }
+}
+
+public extension Field.Kind {
+    @available(*, deprecated, renamed: "fileUpload")
+    static let file_upload: Self = .fileUpload
+    @available(*, deprecated, renamed: "longText")
+    static let long_text: Self = .longText
+    @available(*, deprecated, renamed: "multipleChoice")
+    static let multiple_choice: Self = .multipleChoice
+    @available(*, deprecated, renamed: "opinionScale")
+    static let opinion_scale: Self = .opinionScale
+    @available(*, deprecated, renamed: "shortText")
+    static let short_text: Self = .shortText
+    @available(*, deprecated, renamed: "yesNo")
+    static let yes_no: Self = .yesNo
 }

--- a/Sources/Typeform/Schema/Questions/Dropdown.swift
+++ b/Sources/Typeform/Schema/Questions/Dropdown.swift
@@ -2,15 +2,18 @@ import Foundation
 
 public struct Dropdown: Hashable, Codable {
     public let choices: [Choice]
+    public let description: String?
     public let randomize: Bool
     public let alphabetical_order: Bool
 
     public init(
         choices: [Choice] = [],
+        description: String? = nil,
         randomize: Bool = false,
         alphabetical_order: Bool = true
     ) {
         self.choices = choices
+        self.description = description
         self.randomize = randomize
         self.alphabetical_order = alphabetical_order
     }

--- a/Sources/Typeform/Schema/Questions/FileUpload.swift
+++ b/Sources/Typeform/Schema/Questions/FileUpload.swift
@@ -1,0 +1,7 @@
+public struct FileUpload: Hashable, Codable {
+    public let description: String?
+
+    public init(description: String?) {
+        self.description = description
+    }
+}

--- a/Sources/TypeformPreview/Resources/DemoForm.json
+++ b/Sources/TypeformPreview/Resources/DemoForm.json
@@ -1,7 +1,7 @@
 {
   "id": "hu2FodCY",
   "type": "quiz",
-  "title": "Demo Form 2025-01-15",
+  "title": "All Question Types Demo Form",
   "workspace": {
     "href": "https://api.typeform.com/workspaces/5PY2Nu"
   },
@@ -99,7 +99,7 @@
           {
             "id": "M6IDI3o5xRXu",
             "title": "Do you enjoy using Typeform?",
-            "ref": "group-yes-no-typeform",
+            "ref": "question-group-yes-no-typeform",
             "properties": {
               "description": "Yes/No Question"
             },
@@ -107,21 +107,40 @@
               "required": false
             },
             "type": "yes_no"
+          },
+          {
+            "id": "aUWEtefTVNrl",
+            "title": "Upload your response",
+            "ref": "question-group-file-upload-typeform",
+            "properties": {
+              "description": "Choose a file"
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "file_upload"
           }
         ]
       },
-      "type": "group"
-    },
-    {
-      "id": "7BP0MLinDRSK",
-      "title": "We're sorry to hear that you aren't enjoying Typeform.",
-      "ref": "statement-typeform",
-      "properties": {
-        "description": "Let us know how we can do better!",
-        "button_text": "Okay",
-        "hide_marks": true
+      "type": "group",
+      "attachment": {
+        "type": "image",
+        "href": "https://images.typeform.com/images/ehHzhjZQS4FL",
+        "properties": {
+          "description": "v4-460px-Calculate-Your-Heart-Rate-Step-1-Version-2"
+        }
       },
-      "type": "statement"
+      "layout": {
+        "type": "stack",
+        "attachment": {
+          "type": "image",
+          "href": "https://images.typeform.com/images/ehHzhjZQS4FL",
+          "properties": {
+            "description": "v4-460px-Calculate-Your-Heart-Rate-Step-1-Version-2"
+          }
+        },
+        "viewport_overrides": {}
+      }
     },
     {
       "id": "JmxJ5tpY1WQI",
@@ -134,6 +153,17 @@
         "required": true
       },
       "type": "yes_no"
+    },
+    {
+      "id": "7BP0MLinDRSK",
+      "title": "We're sorry to hear that you aren't enjoying Typeform.",
+      "ref": "statement-typeform",
+      "properties": {
+        "description": "Let us know how we can do better!",
+        "button_text": "Okay",
+        "hide_marks": true
+      },
+      "type": "statement"
     },
     {
       "id": "t5R9fs0sl5mo",
@@ -371,8 +401,8 @@
       },
       "validations": {
         "required": true,
-        "min_selection": 4,
-        "max_selection": 4
+        "min_selection": 1,
+        "max_selection": 5
       },
       "type": "multiple_choice"
     },
@@ -901,7 +931,7 @@
     },
     {
       "type": "field",
-      "ref": "group-yes-no-typeform",
+      "ref": "question-group-yes-no-typeform",
       "actions": [
         {
           "action": "jump",
@@ -916,7 +946,7 @@
             "vars": [
               {
                 "type": "field",
-                "value": "group-yes-no-typeform"
+                "value": "question-group-yes-no-typeform"
               },
               {
                 "type": "constant",
@@ -930,7 +960,7 @@
           "details": {
             "to": {
               "type": "field",
-              "value": "number-typeform"
+              "value": "question-group-file-upload-typeform"
             }
           },
           "condition": {
@@ -948,8 +978,8 @@
           "action": "jump",
           "details": {
             "to": {
-              "type": "thankyou",
-              "value": "thank-you-2-typeform"
+              "type": "field",
+              "value": "number-typeform"
             }
           },
           "condition": {
@@ -1010,6 +1040,25 @@
             "to": {
               "type": "field",
               "value": "multiple-choice-typeform"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "question-group-file-upload-typeform",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "yes-no-typeform"
             }
           },
           "condition": {

--- a/Sources/TypeformUI/Components/IntermittentChoiceButtonStyle.swift
+++ b/Sources/TypeformUI/Components/IntermittentChoiceButtonStyle.swift
@@ -78,7 +78,7 @@ struct IntermittentChoiceButtonStyle: ButtonStyle {
     }
 }
 
-struct ChoiceButtonStyle_Previews: PreviewProvider {
+struct IntermittentChoiceButtonStyle_Previews: PreviewProvider {
     static var previews: some View {
         ScrollView {
             MultipleChoiceView(

--- a/Sources/TypeformUI/Components/IntermittentTheme.swift
+++ b/Sources/TypeformUI/Components/IntermittentTheme.swift
@@ -33,6 +33,7 @@ public struct IntermittentTheme {
 }
 
 public extension IntermittentTheme {
+    static let upload: IntermittentTheme = IntermittentTheme()
     static let button: IntermittentTheme = IntermittentTheme()
     static let checkbox: IntermittentTheme = IntermittentTheme()
     static let radio: IntermittentTheme = IntermittentTheme(

--- a/Sources/TypeformUI/Components/UploadImageView.swift
+++ b/Sources/TypeformUI/Components/UploadImageView.swift
@@ -7,7 +7,7 @@ struct UploadImageView: View {
 
     var upload: Upload
     var settings: Settings
-    var removeAction: () -> Void = { }
+    var removeAction: () -> Void = {}
 
     private let padding = EdgeInsets(top: 8.0, leading: 8.0, bottom: 8.0, trailing: 8.0)
 

--- a/Sources/TypeformUI/Components/UploadImageView.swift
+++ b/Sources/TypeformUI/Components/UploadImageView.swift
@@ -9,6 +9,8 @@ struct UploadImageView: View {
     var settings: Settings
     var removeAction: () -> Void = { }
 
+    private let padding = EdgeInsets(top: 8.0, leading: 8.0, bottom: 8.0, trailing: 8.0)
+
     var body: some View {
         VStack(alignment: .leading) {
             ZStack(alignment: .topTrailing) {
@@ -20,19 +22,12 @@ struct UploadImageView: View {
                         .clipShape(
                             RoundedRectangle(cornerRadius: settings.upload.imageRadius)
                         )
-                        .padding(8)
+                        .padding(padding)
                 } else {
-                    ZStack {
-                        RoundedRectangle(cornerRadius: settings.upload.imageRadius)
-                            .aspectRatio(contentMode: .fit)
-                            .foregroundStyle(settings.upload.theme.selectedBackgroundColor)
-                            .padding(8)
-
-                        Image(systemName: "doc.on.clipboard")
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(width: 60)
-                    }
+                    UploadPlaceholderView(
+                        settings: settings,
+                        padding: padding
+                    )
                 }
                 #elseif canImport(AppKit)
                 if let image = NSImage(data: upload.bytes) {
@@ -42,19 +37,12 @@ struct UploadImageView: View {
                         .clipShape(
                             RoundedRectangle(cornerRadius: settings.upload.imageRadius)
                         )
-                        .padding(8)
+                        .padding(padding)
                 } else {
-                    ZStack {
-                        RoundedRectangle(cornerRadius: settings.upload.imageRadius)
-                            .aspectRatio(contentMode: .fit)
-                            .foregroundStyle(settings.upload.theme.selectedBackgroundColor)
-                            .padding(8)
-
-                        Image(systemName: "doc.on.clipboard")
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(width: 60)
-                    }
+                    UploadPlaceholderView(
+                        settings: settings,
+                        padding: padding
+                    )
                 }
                 #endif
 
@@ -67,12 +55,41 @@ struct UploadImageView: View {
                         .clipShape(Circle())
                 }
             }
-            .frame(maxWidth: 200)
+            .frame(maxWidth: settings.upload.imageMaxWidth)
 
             Text(upload.fileName)
                 .font(settings.typography.captionFont)
                 .foregroundStyle(settings.typography.captionColor)
-                .padding(.leading, 8)
+                .padding(.leading, padding.leading)
+        }
+    }
+}
+
+struct UploadPlaceholderView: View {
+
+    var settings: Settings
+    var padding: EdgeInsets
+
+    private var glyphWidth: CGFloat {
+        if let width = settings.upload.imageMaxWidth {
+            width * 0.3
+        } else {
+            60
+        }
+    }
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: settings.upload.imageRadius)
+                .aspectRatio(contentMode: .fit)
+                .foregroundStyle(settings.upload.placeholderBackgroundColor)
+                .padding(padding)
+
+            Image(systemName: "doc.on.clipboard")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .foregroundStyle(settings.upload.placeholderForegroundColor)
+                .frame(width: glyphWidth)
         }
     }
 }

--- a/Sources/TypeformUI/Components/UploadImageView.swift
+++ b/Sources/TypeformUI/Components/UploadImageView.swift
@@ -1,0 +1,91 @@
+#if canImport(SwiftUI)
+import SwiftUI
+import Typeform
+import TypeformPreview
+
+struct UploadImageView: View {
+
+    var upload: Upload
+    var settings: Settings
+    var removeAction: () -> Void = { }
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            ZStack(alignment: .topTrailing) {
+                #if canImport(UIKit)
+                if let image = UIImage(data: upload.bytes) {
+                    Image(uiImage: image)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .clipShape(
+                            RoundedRectangle(cornerRadius: settings.upload.imageRadius)
+                        )
+                        .padding(8)
+                } else {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: settings.upload.imageRadius)
+                            .aspectRatio(contentMode: .fit)
+                            .foregroundStyle(settings.upload.theme.selectedBackgroundColor)
+                            .padding(8)
+
+                        Image(systemName: "doc.on.clipboard")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 60)
+                    }
+                }
+                #elseif canImport(AppKit)
+                if let image = NSImage(data: upload.bytes) {
+                    Image(nsImage: image)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .clipShape(
+                            RoundedRectangle(cornerRadius: settings.upload.imageRadius)
+                        )
+                        .padding(8)
+                } else {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: settings.upload.imageRadius)
+                            .aspectRatio(contentMode: .fit)
+                            .foregroundStyle(settings.upload.theme.selectedBackgroundColor)
+                            .padding(8)
+
+                        Image(systemName: "doc.on.clipboard")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 60)
+                    }
+                }
+                #endif
+
+                Button {
+                    removeAction()
+                } label: {
+                    Label("Remove", systemImage: "x.circle.fill")
+                        .labelStyle(.iconOnly)
+                        .background(settings.button.theme.unselectedBackgroundColor)
+                        .clipShape(Circle())
+                }
+            }
+            .frame(maxWidth: 200)
+
+            Text(upload.fileName)
+                .font(settings.typography.captionFont)
+                .foregroundStyle(settings.typography.captionColor)
+                .padding(.leading, 8)
+        }
+    }
+}
+
+#Preview("Upload Image") {
+    UploadImageView(
+        upload: Upload(
+            bytes: Data(),
+            path: .camera,
+            mimeType: "image/jpeg",
+            fileName: "IMG_1234567890.jpg"
+        ),
+        settings: Settings()
+    )
+}
+#endif

--- a/Sources/TypeformUI/Components/UploadLabelStyle.swift
+++ b/Sources/TypeformUI/Components/UploadLabelStyle.swift
@@ -1,0 +1,65 @@
+#if canImport(SwiftUI)
+import SwiftUI
+import Typeform
+import TypeformPreview
+
+struct UploadLabelStyle: LabelStyle {
+
+    let settings: Settings
+
+    private var backgroundColor: Color {
+        settings.upload.theme.unselectedBackgroundColor
+    }
+
+    private var strokeColor: Color {
+        settings.upload.theme.unselectedStrokeColor
+    }
+
+    private var strokeWidth: Double {
+        settings.upload.theme.unselectedStrokeWidth
+    }
+
+    private var foregroundColor: Color {
+        settings.typography.bodyColor
+    }
+
+    private var shape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: settings.upload.actionRadius)
+    }
+
+    init(settings: Settings) {
+        self.settings = settings
+    }
+
+    func makeBody(configuration: Configuration) -> some View {
+        HStack {
+            configuration.icon
+            configuration.title
+        }
+        .font(settings.typography.bodyFont)
+        .foregroundColor(foregroundColor)
+        .frame(maxWidth: .infinity)
+        .padding(settings.button.padding)
+        .background(
+            backgroundColor.clipShape(shape)
+        )
+        .overlay(
+            shape.stroke(strokeColor, lineWidth: strokeWidth)
+        )
+    }
+}
+
+#Preview("Upload Label Style") {
+    Menu {
+        Button("One") {}
+        Button("Two") {}
+    } label: {
+        Label("Add", systemImage: "plus")
+            .labelStyle(
+                UploadLabelStyle(
+                    settings: Settings()
+                )
+            )
+    }
+}
+#endif

--- a/Sources/TypeformUI/Components/UploadPickerView.swift
+++ b/Sources/TypeformUI/Components/UploadPickerView.swift
@@ -1,0 +1,191 @@
+#if canImport(SwiftUI) && canImport(UIKit)
+import PhotosUI
+import SwiftUI
+import Typeform
+import UniformTypeIdentifiers
+
+struct UploadPickerView: UIViewControllerRepresentable {
+
+    var path: Upload.Path
+    var resultHandler: (Result<Upload, Error>?) -> Void
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        switch path {
+        case .camera:
+            let controller = UIImagePickerController()
+            controller.sourceType = .camera
+            controller.delegate = context.coordinator
+            controller.allowsEditing = true
+            return controller
+        case .photoLibrary:
+            var config = PHPickerConfiguration()
+            config.filter = .any(of: [.images, .screenshots])
+
+            let controller = PHPickerViewController(configuration: config)
+            controller.delegate = context.coordinator
+            return controller
+        case .documents:
+            let contentTypes: [UTType] = [
+                .jpeg,
+                .png,
+                .pdf
+            ]
+            
+            let controller = UIDocumentPickerViewController(forOpeningContentTypes: contentTypes)
+            controller.delegate = context.coordinator
+            return controller
+        }
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+
+    func makeCoordinator() -> UploadPickerCoordinator {
+        UploadPickerCoordinator(path: path, resultHandler: resultHandler)
+    }
+}
+
+class UploadPickerCoordinator: NSObject, UINavigationControllerDelegate {
+
+    let path: Upload.Path
+    let resultHandler: (Result<Upload, Error>?) -> Void
+
+    init(
+        path: Upload.Path,
+        resultHandler: @escaping (Result<Upload, Error>?) -> Void
+    ) {
+        self.path = path
+        self.resultHandler = resultHandler
+    }
+}
+
+extension UploadPickerCoordinator: UIImagePickerControllerDelegate {
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+        let image: UIImage? = if let image = info[.editedImage] as? UIImage {
+            image
+        } else if let image = info[.originalImage] as? UIImage {
+            image
+        } else {
+            nil
+        }
+
+        guard let image else {
+            resultHandler(.failure(TypeformError.fileUploadSelection))
+            return
+        }
+
+        guard let bytes = image.jpegData(compressionQuality: 0.9) else {
+            resultHandler(.failure(TypeformError.fileUploadData))
+            return
+        }
+
+        let upload = Upload(
+            bytes: bytes,
+            path: .camera,
+            mimeType: UTType.jpeg.preferredMIMEType ?? "image/jpeg"
+        )
+
+        resultHandler(.success(upload))
+    }
+
+    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+        resultHandler(nil)
+    }
+}
+
+extension UploadPickerCoordinator: PHPickerViewControllerDelegate {
+    func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        guard let provider = results.first?.itemProvider else {
+            resultHandler(nil)
+            return
+        }
+
+        guard provider.canLoadObject(ofClass: UIImage.self) else {
+            resultHandler(.failure(TypeformError.fileUploadSelection))
+            return
+        }
+
+        Task {
+            let result: Result<Upload, Error>
+            do {
+                let image = try await image(from: provider)
+                guard let bytes = image.jpegData(compressionQuality: 0.9) else {
+                    throw TypeformError.fileUploadData
+                }
+
+                let upload = Upload(
+                    bytes: bytes,
+                    path: .photoLibrary,
+                    mimeType: UTType.jpeg.preferredMIMEType ?? "image/jpeg"
+                )
+                result = .success(upload)
+            } catch {
+                result = .failure(error)
+            }
+
+            await MainActor.run {
+                resultHandler(result)
+            }
+        }
+    }
+
+    private func image(from provider: NSItemProvider) async throws -> UIImage {
+        try await withCheckedThrowingContinuation { continuation in
+            provider.loadObject(ofClass: UIImage.self) { reading, error in
+                switch (reading, error) {
+                case (.some(let image as UIImage), _):
+                    continuation.resume(returning: image)
+                case (_, .some(let throwing)):
+                    continuation.resume(throwing: throwing)
+                default:
+                    continuation.resume(throwing: CocoaError(.fileReadCorruptFile))
+                }
+            }
+        }
+    }
+}
+
+// `UIDocumentPickerViewController` is automatically dismissed
+extension UploadPickerCoordinator: UIDocumentPickerDelegate {
+    func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+        guard let url = urls.first else {
+            resultHandler(.failure(TypeformError.fileUploadSelection))
+            return
+        }
+
+        do {
+            guard url.startAccessingSecurityScopedResource() else {
+                throw TypeformError.fileUploadSecurity
+            }
+
+            defer {
+                url.stopAccessingSecurityScopedResource()
+            }
+
+            guard let bytes = try? Data(contentsOf: url) else {
+                throw TypeformError.fileUploadData
+            }
+
+            guard let resourceValues = try? url.resourceValues(forKeys: [.contentTypeKey]) else {
+                throw TypeformError.fileUploadData
+            }
+
+            let uniformType = resourceValues.contentType ?? .fileURL
+            let mimeType = uniformType.preferredMIMEType ?? "application/octet-stream"
+
+            let upload = Upload(
+                bytes: bytes,
+                path: .documents,
+                mimeType: mimeType
+            )
+
+            resultHandler(.success(upload))
+        } catch {
+            resultHandler(.failure(error))
+        }
+    }
+
+    func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+        resultHandler(nil)
+    }
+}
+#endif

--- a/Sources/TypeformUI/Components/UploadPickerView.swift
+++ b/Sources/TypeformUI/Components/UploadPickerView.swift
@@ -32,7 +32,7 @@ struct UploadPickerView: UIViewControllerRepresentable {
                 .heic,
                 .heif,
             ]
-            
+
             let controller = UIDocumentPickerViewController(forOpeningContentTypes: contentTypes)
             controller.delegate = context.coordinator
             return controller
@@ -61,7 +61,7 @@ class UploadPickerCoordinator: NSObject, UINavigationControllerDelegate {
 }
 
 extension UploadPickerCoordinator: UIImagePickerControllerDelegate {
-    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
         let image: UIImage? = if let image = info[.editedImage] as? UIImage {
             image
         } else if let image = info[.originalImage] as? UIImage {

--- a/Sources/TypeformUI/Fields/FileUploadView.swift
+++ b/Sources/TypeformUI/Fields/FileUploadView.swift
@@ -1,0 +1,153 @@
+#if canImport(SwiftUI)
+import SwiftUI
+import Typeform
+import TypeformPreview
+
+struct FileUploadView: View {
+
+    var state: Binding<ResponseState>
+    var properties: FileUpload
+    var settings: Settings
+    var validations: Validations?
+
+    @State private var value: Upload?
+    @State private var path: Upload.Path?
+    @State private var error: Error?
+
+    private var image: UIImage? {
+        guard let value else {
+            return nil
+        }
+
+        guard value.mimeType.hasPrefix("image") else {
+            return nil
+        }
+
+        return UIImage(data: value.bytes)
+    }
+
+    var body: some View {
+        VStack(spacing: settings.presentation.contentVerticalSpacing) {
+            if value != nil {
+                ZStack(alignment: .topTrailing) {
+                    if let image {
+                        Image(uiImage: image)
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .clipShape(
+                                RoundedRectangle(cornerRadius: settings.upload.imageRadius)
+                            )
+                            .padding(8)
+                    } else {
+                        Image(systemName: "doc")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .clipShape(
+                                RoundedRectangle(cornerRadius: settings.upload.imageRadius)
+                            )
+                            .padding(8)
+                    }
+
+                    Button {
+                        value = nil
+                    } label: {
+                        Label("Remove", systemImage: "x.circle.fill")
+                            .labelStyle(.iconOnly)
+                            .background(settings.button.theme.unselectedBackgroundColor)
+                            .clipShape(Circle())
+                    }
+                }
+            } else {
+                Menu {
+                    Button {
+                        path = .camera
+                    } label: {
+                        Label(settings.localization.uploadCamera, systemImage: "camera")
+                    }
+                    Button {
+                        path = .photoLibrary
+                    } label: {
+                        Label(settings.localization.uploadPhotoLibrary, systemImage: "photo")
+                    }
+                    Button {
+                        path = .documents
+                    } label: {
+                        Label(settings.localization.uploadDocument, systemImage: "folder")
+                    }
+                } label: {
+                    Label(settings.localization.uploadAction, systemImage: "plus")
+                        .labelStyle(UploadLabelStyle(settings: settings))
+                }
+            }
+
+            if let error {
+                Text(error.localizedDescription)
+            }
+        }
+        .sheet(item: $path) { uploadPath in
+            UploadPickerView(path: uploadPath) { result in
+                handlePickerResult(result)
+            }
+        }
+        .onAppear {
+            registerState()
+        }
+        .onChange(of: value) { _ in
+            updateState()
+        }
+    }
+
+    private func registerState() {
+        switch state.wrappedValue.response {
+        case .upload(let upload):
+            value = upload
+        default:
+            value = nil
+        }
+
+        updateState()
+    }
+
+    private func updateState() {
+        var state = state.wrappedValue
+
+        if let response = value {
+            state.response = .upload(response)
+        } else {
+            state.response = nil
+        }
+
+        if let validations, validations.required {
+            state.invalid = value == nil
+        } else {
+            state.invalid = false
+        }
+
+        self.state.wrappedValue = state
+    }
+
+    private func handlePickerResult(_ result: Result<Upload, Error>?) {
+        path = nil
+
+        switch result {
+        case .success(let upload):
+            value = upload
+            error = nil
+        case .failure(let failure):
+            value = nil
+            error = failure
+        case nil:
+            value = nil
+            error = nil
+        }
+    }
+}
+
+#Preview("File Upload View") {
+    FileUploadView(
+        state: .constant(ResponseState()),
+        properties: FileUpload(description: nil),
+        settings: Settings()
+    )
+}
+#endif

--- a/Sources/TypeformUI/Fields/FileUploadView.swift
+++ b/Sources/TypeformUI/Fields/FileUploadView.swift
@@ -66,7 +66,6 @@ struct FileUploadView: View {
             UploadPickerView(path: uploadPath) { result in
                 handlePickerResult(result)
             }
-
         }
         #endif
         .onAppear {

--- a/Sources/TypeformUI/Settings.swift
+++ b/Sources/TypeformUI/Settings.swift
@@ -16,6 +16,10 @@ public struct Settings {
         public var abandonConfirmationAction: String
         public var emptyChoice: String
         public var nullDate: String
+        public var uploadAction: String
+        public var uploadCamera: String
+        public var uploadPhotoLibrary: String
+        public var uploadDocument: String
 
         public init(
             next: String = "Next",
@@ -28,7 +32,11 @@ public struct Settings {
             abandonConfirmationMessage: String = "Are you sure you want to abandon the form?",
             abandonConfirmationAction: String = "Abandon",
             emptyChoice: String = "Select Option",
-            nullDate: String = "I'm not sure…"
+            nullDate: String = "I'm not sure…",
+            uploadAction: String = "Select File",
+            uploadCamera: String = "Camera",
+            uploadPhotoLibrary: String = "Photo Library",
+            uploadDocument: String = "Documents"
         ) {
             self.next = next
             self.cancel = cancel
@@ -41,6 +49,10 @@ public struct Settings {
             self.abandonConfirmationMessage = abandonConfirmationMessage
             self.emptyChoice = emptyChoice
             self.nullDate = nullDate
+            self.uploadAction = uploadAction
+            self.uploadCamera = uploadCamera
+            self.uploadPhotoLibrary = uploadPhotoLibrary
+            self.uploadDocument = uploadDocument
         }
     }
 
@@ -228,6 +240,25 @@ public struct Settings {
         public init() {}
     }
 
+    public struct Upload {
+        public var theme: IntermittentTheme
+        public var actionRadius: Double
+        public var imageRadius: Double
+        public var padding: EdgeInsets
+
+        public init(
+            theme: IntermittentTheme = .upload,
+            actionRadius: Double = 3.0,
+            imageRadius: Double = 6.0,
+            padding: EdgeInsets = EdgeInsets(top: 15.0, leading: 10.0, bottom: 15.0, trailing: 10.0)
+        ) {
+            self.theme = theme
+            self.actionRadius = actionRadius
+            self.imageRadius = imageRadius
+            self.padding = padding
+        }
+    }
+
     public var localization: Localization
     public var presentation: Presentation
     public var typography: Typography
@@ -238,6 +269,7 @@ public struct Settings {
     public var radio: Radio
     public var rating: Rating
     public var opinionScale: OpinionScale
+    public var upload: Upload
 
     public init(
         localization: Localization = Localization(),
@@ -249,7 +281,8 @@ public struct Settings {
         checkbox: Checkbox = Checkbox(),
         radio: Radio = Radio(),
         rating: Rating = Rating(),
-        opinionScale: OpinionScale = OpinionScale()
+        opinionScale: OpinionScale = OpinionScale(),
+        upload: Upload = Upload()
     ) {
         self.localization = localization
         self.presentation = presentation
@@ -261,6 +294,7 @@ public struct Settings {
         self.radio = radio
         self.rating = rating
         self.opinionScale = opinionScale
+        self.upload = upload
     }
 }
 #endif

--- a/Sources/TypeformUI/Settings.swift
+++ b/Sources/TypeformUI/Settings.swift
@@ -79,10 +79,10 @@ public struct Settings {
         public init(
             layout: Layout = .callToAction,
             backgroundColor: Color = .white,
-            titleDescriptionVerticalSpacing: Double = 30.0,
-            descriptionContentVerticalSpacing: Double = 30.0,
+            titleDescriptionVerticalSpacing: CGFloat = 30.0,
+            descriptionContentVerticalSpacing: CGFloat = 30.0,
             contentInsets: EdgeInsets = EdgeInsets(),
-            contentVerticalSpacing: Double = 15.0,
+            contentVerticalSpacing: CGFloat = 15.0,
             showWelcomeImage: Bool = true,
             showEndingImage: Bool = true,
             skipWelcomeScreen: Bool = false,
@@ -147,13 +147,13 @@ public struct Settings {
         public var backgroundColor: Color
         public var dividerColor: Color
         public var insets: EdgeInsets
-        public var verticalSpacing: Double
+        public var verticalSpacing: CGFloat
 
         public init(
             backgroundColor: Color = .white,
             dividerColor: Color = .black,
             insets: EdgeInsets = EdgeInsets(),
-            verticalSpacing: Double = 0.0
+            verticalSpacing: CGFloat = 0.0
         ) {
             self.backgroundColor = backgroundColor
             self.dividerColor = dividerColor
@@ -165,18 +165,18 @@ public struct Settings {
     public struct Field {
         public var backgroundColor: Color
         public var strokeColor: Color
-        public var strokeWidth: Double
-        public var verticalInset: Double
-        public var horizontalInset: Double
-        public var cornerRadius: Double
+        public var strokeWidth: CGFloat
+        public var verticalInset: CGFloat
+        public var horizontalInset: CGFloat
+        public var cornerRadius: CGFloat
 
         public init(
             backgroundColor: Color = .gray.opacity(0.2),
             strokeColor: Color = .gray.opacity(0.8),
-            strokeWidth: Double = 1.0,
-            verticalInset: Double = 10.0,
-            horizontalInset: Double = 15.0,
-            cornerRadius: Double = 6.0
+            strokeWidth: CGFloat = 1.0,
+            verticalInset: CGFloat = 10.0,
+            horizontalInset: CGFloat = 15.0,
+            cornerRadius: CGFloat = 6.0
         ) {
             self.backgroundColor = backgroundColor
             self.strokeColor = strokeColor
@@ -189,12 +189,12 @@ public struct Settings {
 
     public struct Button {
         public var theme: IntermittentTheme
-        public var cornerRadius: Double
+        public var cornerRadius: CGFloat
         public var padding: EdgeInsets
 
         public init(
             theme: IntermittentTheme = .button,
-            cornerRadius: Double = 6.0,
+            cornerRadius: CGFloat = 6.0,
             padding: EdgeInsets = EdgeInsets(top: 15.0, leading: 10.0, bottom: 15.0, trailing: 10.0)
         ) {
             self.theme = theme
@@ -205,11 +205,11 @@ public struct Settings {
 
     public struct Checkbox {
         public var theme: IntermittentTheme
-        public var cornerRadius: Double
+        public var cornerRadius: CGFloat
 
         public init(
             theme: IntermittentTheme = .checkbox,
-            cornerRadius: Double = 3.0
+            cornerRadius: CGFloat = 3.0
         ) {
             self.theme = theme
             self.cornerRadius = cornerRadius
@@ -242,20 +242,26 @@ public struct Settings {
 
     public struct Upload {
         public var theme: IntermittentTheme
-        public var actionRadius: Double
-        public var imageRadius: Double
-        public var padding: EdgeInsets
+        public var actionRadius: CGFloat
+        public var imageRadius: CGFloat
+        public var imageMaxWidth: CGFloat?
+        public var placeholderBackgroundColor: Color
+        public var placeholderForegroundColor: Color
 
         public init(
             theme: IntermittentTheme = .upload,
-            actionRadius: Double = 3.0,
-            imageRadius: Double = 6.0,
-            padding: EdgeInsets = EdgeInsets(top: 15.0, leading: 10.0, bottom: 15.0, trailing: 10.0)
+            actionRadius: CGFloat = 3.0,
+            imageRadius: CGFloat = 16.0,
+            imageMaxWidth: CGFloat? = 200,
+            placeholderBackgroundColor: Color = .blue,
+            placeholderForegroundColor: Color = .white
         ) {
             self.theme = theme
             self.actionRadius = actionRadius
             self.imageRadius = imageRadius
-            self.padding = padding
+            self.imageMaxWidth = imageMaxWidth
+            self.placeholderBackgroundColor = placeholderBackgroundColor
+            self.placeholderForegroundColor = placeholderForegroundColor
         }
     }
 

--- a/Sources/TypeformUI/Structure/FieldView.swift
+++ b/Sources/TypeformUI/Structure/FieldView.swift
@@ -88,6 +88,13 @@ struct FieldView<Header: View, Footer: View>: View {
                                 settings: settings,
                                 validations: field.validations
                             )
+                        case .fileUpload(let properties):
+                            FileUploadView(
+                                state: $responseState,
+                                properties: properties,
+                                settings: settings,
+                                validations: field.validations
+                            )
                         case .group:
                             EmptyView()
                         case .longText(let properties):

--- a/Sources/TypeformUI/Structure/FormView.swift
+++ b/Sources/TypeformUI/Structure/FormView.swift
@@ -77,6 +77,9 @@ public struct FormView<Header: View, Footer: View>: View {
             .navigationBarTitleDisplayMode(.inline)
             #endif
         }
+        #if os(iOS)
+        .navigationViewStyle(.stack)
+        #endif
     }
 }
 


### PR DESCRIPTION
# Description

Adds support for the **file_upload** field type. File uploads are currently limited to `UIKit` environments and can only include Images & PDFs. The `ResponseValue.upload(Upload)` enumeration has been added and will be included in the response mapping on conclusion of the `Form`.

The `FileUploadView` has configurable options that can be specified as part of the `TypeformUI.Settings` (This includes localizations for the upload actions/options).

Internal reference: MOB-318

## New/Updated Features

| Select File | Image 1 | Image 2 |
| --- | --- | --- |
| ![U1](https://github.com/user-attachments/assets/28ce92f9-acd8-43f9-9873-d9bfdbda4da7) | ![U2](https://github.com/user-attachments/assets/4fa7df99-ec5a-4bd8-8ac8-195840538c86) | ![U3](https://github.com/user-attachments/assets/c2018ed5-8517-4467-aeee-775c91b19a84) |

