### PR TITLE
Override Button Styles

### DIFF
--- a/Sources/TypeformUI/Components/UploadImageView.swift
+++ b/Sources/TypeformUI/Components/UploadImageView.swift
@@ -51,8 +51,8 @@ struct UploadImageView: View {
                 } label: {
                     Label("Remove", systemImage: "x.circle.fill")
                         .labelStyle(.iconOnly)
-                        .background(settings.button.theme.unselectedBackgroundColor)
-                        .foregroundStyle(settings.button.theme.selectedBackgroundColor)
+                        .background(settings.radio.theme.selectedBackgroundColor)
+                        .foregroundStyle(settings.radio.theme.selectedForegroundColor)
                         .clipShape(Circle())
                 }
                 .buttonStyle(.plain)

--- a/Sources/TypeformUI/Components/UploadImageView.swift
+++ b/Sources/TypeformUI/Components/UploadImageView.swift
@@ -52,8 +52,10 @@ struct UploadImageView: View {
                     Label("Remove", systemImage: "x.circle.fill")
                         .labelStyle(.iconOnly)
                         .background(settings.button.theme.unselectedBackgroundColor)
+                        .foregroundStyle(settings.button.theme.selectedBackgroundColor)
                         .clipShape(Circle())
                 }
+                .buttonStyle(.plain)
             }
             .frame(maxWidth: settings.upload.imageMaxWidth)
 

--- a/Sources/TypeformUI/Fields/FileUploadView.swift
+++ b/Sources/TypeformUI/Fields/FileUploadView.swift
@@ -45,6 +45,7 @@ struct FileUploadView: View {
                     Label(settings.localization.uploadAction, systemImage: "plus")
                         .labelStyle(UploadLabelStyle(settings: settings))
                 }
+                .buttonStyle(.plain)
                 #elseif canImport(AppKit)
                 Button {
                     selectFile()
@@ -52,6 +53,7 @@ struct FileUploadView: View {
                     Label(settings.localization.uploadAction, systemImage: "plus")
                         .labelStyle(UploadLabelStyle(settings: settings))
                 }
+                .buttonStyle(.plain)
                 #else
                 Text("Unsupported Platform")
                 #endif


### PR DESCRIPTION
# Description

A followup to #29. When using the recommended method for applying button styles to the 'call-to-action' style buttons, you can unintentionally apply styling to other button types (like the file upload and remove image buttons).

This forces a 'plain' button style on those new items allowing the new label styles to appear as expected. This more closely matches our internal styling usage (MOB-318)

## New/Updated Features

| Upload Style | Remove Image |
| --- | --- |
| ![b1](https://github.com/user-attachments/assets/6e22b0e4-2f1c-46fb-9c36-abf3c1d0ef22) | ![b2](https://github.com/user-attachments/assets/11263d17-9253-4ad1-b128-7e98f34e28cd) |

