### PR TITLE
Expanded Hashable Conformances

### DIFF
--- a/Sources/Typeform/Models/ResponseValue.swift
+++ b/Sources/Typeform/Models/ResponseValue.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum ResponseValue: Equatable {
+public enum ResponseValue: Hashable {
     case bool(Bool)
     case choice(Choice)
     case choices([Choice])

--- a/Sources/Typeform/Models/Upload.swift
+++ b/Sources/Typeform/Models/Upload.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-public struct Upload: Equatable {
+public struct Upload: Hashable {
 
-    public enum Path: String, Identifiable {
+    public enum Path: String, Hashable, Identifiable {
         case camera
         case photoLibrary
         case documents

--- a/Sources/Typeform/Schema/Structure/EndingScreen.swift
+++ b/Sources/Typeform/Schema/Structure/EndingScreen.swift
@@ -33,7 +33,7 @@ public struct EndingScreen: Screen, Hashable, Codable {
     public let ref: Ref
     public let type: String
     public let title: String
-    public let attachment: ScreenAttachment?
+    public let attachment: Attachment?
     public let properties: ScreenProperties
 
     public init(
@@ -41,7 +41,7 @@ public struct EndingScreen: Screen, Hashable, Codable {
         ref: Ref = .default,
         type: String = "thankyou_screen",
         title: String = "",
-        attachment: ScreenAttachment? = nil,
+        attachment: Attachment? = nil,
         properties: ScreenProperties = ScreenProperties()
     ) {
         self.id = id

--- a/Sources/Typeform/Schema/Structure/WelcomeScreen.swift
+++ b/Sources/Typeform/Schema/Structure/WelcomeScreen.swift
@@ -4,14 +4,14 @@ public struct WelcomeScreen: Screen, Hashable, Codable {
     public let id: String
     public let ref: Reference
     public let title: String
-    public let attachment: ScreenAttachment?
+    public let attachment: Attachment?
     public let properties: ScreenProperties
 
     public init(
         id: String = "",
         ref: Reference = Reference(),
         title: String = "",
-        attachment: ScreenAttachment? = nil,
+        attachment: Attachment? = nil,
         properties: ScreenProperties = ScreenProperties()
     ) {
         self.id = id


### PR DESCRIPTION
# Description

Updates a few types from conforming from `Equatable` to `Hashable`.

This change helps us internally with some navigation changes.

