### PR TITLE
ResponseValue Serialization

### DIFF
--- a/Sources/Typeform/Models/Reference.swift
+++ b/Sources/Typeform/Models/Reference.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum Reference: Hashable, RawRepresentable, Codable {
+public enum Reference: Hashable, RawRepresentable, ExpressibleByStringLiteral, Codable, Sendable {
     case string(String)
     case uuid(UUID)
 
@@ -31,7 +31,15 @@ public enum Reference: Hashable, RawRepresentable, Codable {
         get {
             switch self {
             case .string(let string): string
-            case .uuid(let uuid): uuid.uuidString
+            case .uuid(let uuid):
+                switch Self.valueEncodingCase {
+                case .automatic:
+                    uuid.uuidString
+                case .uppercase:
+                    uuid.uuidString.uppercased()
+                case .lowercase:
+                    uuid.uuidString.lowercased()
+                }
             }
         }
         set {
@@ -53,6 +61,10 @@ public enum Reference: Hashable, RawRepresentable, Codable {
 
     public init(string: String) {
         self = .string(string)
+    }
+
+    public init(stringLiteral value: String) {
+        self = Self.make(with: value)
     }
 
     public init?(uuidString: String) {

--- a/Sources/Typeform/Models/Reference.swift
+++ b/Sources/Typeform/Models/Reference.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum Reference: Hashable, RawRepresentable, ExpressibleByStringLiteral, Codable, Sendable {
+public enum Reference: Hashable, Sendable {
     case string(String)
     case uuid(UUID)
 
@@ -27,26 +27,6 @@ public enum Reference: Hashable, RawRepresentable, ExpressibleByStringLiteral, C
         return .string(value)
     }
 
-    public var rawValue: String {
-        get {
-            switch self {
-            case .string(let string): string
-            case .uuid(let uuid):
-                switch Self.valueEncodingCase {
-                case .automatic:
-                    uuid.uuidString
-                case .uppercase:
-                    uuid.uuidString.uppercased()
-                case .lowercase:
-                    uuid.uuidString.lowercased()
-                }
-            }
-        }
-        set {
-            self = Self.make(with: newValue)
-        }
-    }
-
     public var uuidString: String? {
         guard case .uuid(let uuid) = self else {
             return nil
@@ -55,16 +35,8 @@ public enum Reference: Hashable, RawRepresentable, ExpressibleByStringLiteral, C
         return uuid.uuidString
     }
 
-    public init?(rawValue: String) {
-        self = Self.make(with: rawValue)
-    }
-
-    public init(string: String) {
+    public init(string: String = "") {
         self = .string(string)
-    }
-
-    public init(stringLiteral value: String) {
-        self = Self.make(with: value)
     }
 
     public init?(uuidString: String) {
@@ -74,11 +46,9 @@ public enum Reference: Hashable, RawRepresentable, ExpressibleByStringLiteral, C
 
         self = .uuid(uuid)
     }
+}
 
-    public init() {
-        self = .string("")
-    }
-
+extension Reference: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
 
@@ -107,6 +77,38 @@ public enum Reference: Hashable, RawRepresentable, ExpressibleByStringLiteral, C
             case .lowercase:
                 try container.encode(uuid.uuidString.lowercased())
             }
+        }
+    }
+}
+
+extension Reference: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
+        self = Self.make(with: value)
+    }
+}
+
+extension Reference: RawRepresentable {
+    public init?(rawValue: String) {
+        self = Self.make(with: rawValue)
+    }
+
+    public var rawValue: String {
+        get {
+            switch self {
+            case .string(let string): string
+            case .uuid(let uuid):
+                switch Self.valueEncodingCase {
+                case .automatic:
+                    uuid.uuidString
+                case .uppercase:
+                    uuid.uuidString.uppercased()
+                case .lowercase:
+                    uuid.uuidString.lowercased()
+                }
+            }
+        }
+        set {
+            self = Self.make(with: newValue)
         }
     }
 }

--- a/Sources/Typeform/Models/ResponseValue.swift
+++ b/Sources/Typeform/Models/ResponseValue.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum ResponseValue: Hashable {
+public enum ResponseValue: Hashable, Codable, Sendable {
     case bool(Bool)
     case choice(Choice)
     case choices([Choice])
@@ -8,4 +8,65 @@ public enum ResponseValue: Hashable {
     case int(Int)
     case string(String)
     case upload(Upload)
+
+    enum CodingKeys: String, CodingKey {
+        case bool
+        case choice
+        case choices
+        case date
+        case int
+        case string
+        case upload
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        var allKeys = ArraySlice(container.allKeys)
+
+        guard let key = allKeys.popFirst(), allKeys.isEmpty else {
+            let context = DecodingError.Context(
+                codingPath: container.codingPath,
+                debugDescription: "Invalid number of keys found, expected one."
+            )
+
+            throw DecodingError.typeMismatch(ResponseValue.self, context)
+        }
+
+        switch key {
+        case .bool:
+            self = try ResponseValue.bool(container.decode(Bool.self, forKey: .bool))
+        case .choice:
+            self = try ResponseValue.choice(container.decode(Choice.self, forKey: .choice))
+        case .choices:
+            self = try ResponseValue.choices(container.decode([Choice].self, forKey: .choices))
+        case .date:
+            self = try ResponseValue.date(container.decode(Date.self, forKey: .date))
+        case .int:
+            self = try ResponseValue.int(container.decode(Int.self, forKey: .int))
+        case .string:
+            self = try ResponseValue.string(container.decode(String.self, forKey: .string))
+        case .upload:
+            self = try ResponseValue.upload(container.decode(Upload.self, forKey: .upload))
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .bool(let value):
+            try container.encode(value, forKey: .bool)
+        case .choice(let value):
+            try container.encode(value, forKey: .choice)
+        case .choices(let value):
+            try container.encode(value, forKey: .choices)
+        case .date(let value):
+            try container.encode(value, forKey: .date)
+        case .int(let value):
+            try container.encode(value, forKey: .int)
+        case .string(let value):
+            try container.encode(value, forKey: .string)
+        case .upload(let value):
+            try container.encode(value, forKey: .upload)
+        }
+    }
 }

--- a/Sources/Typeform/Models/Responses.swift
+++ b/Sources/Typeform/Models/Responses.swift
@@ -1,1 +1,27 @@
+import Foundation
+
 public typealias Responses = [Reference: ResponseValue]
+
+public extension Responses {
+    /// The default internal implementation of `Codable` conformance on `Dictionary`
+    /// will automatically fall back to alternating key/value pairs in an _un-keyed_ container
+    /// when the `Key` is not a `String` or `Int`.
+    var encodableDictionary: [String: ResponseValue] {
+        reduce([String: ResponseValue]()) { partialResult, pair in
+            var result = partialResult
+            result[pair.key.rawValue] = pair.value
+            return result
+        }
+    }
+}
+
+public extension JSONDecoder {
+    func decodeResponses(from data: Data) throws -> Responses {
+        let dictionary = try decode([String: ResponseValue].self, from: data)
+        return dictionary.reduce([Reference: ResponseValue]()) { partialResult, pair in
+            var result = partialResult
+            result[Reference.make(with: pair.key)] = pair.value
+            return result
+        }
+    }
+}

--- a/Sources/Typeform/Models/Responses.swift
+++ b/Sources/Typeform/Models/Responses.swift
@@ -7,21 +7,14 @@ public extension Responses {
     /// will automatically fall back to alternating key/value pairs in an _un-keyed_ container
     /// when the `Key` is not a `String` or `Int`.
     var encodableDictionary: [String: ResponseValue] {
-        reduce([String: ResponseValue]()) { partialResult, pair in
-            var result = partialResult
-            result[pair.key.rawValue] = pair.value
-            return result
-        }
+        reduce(into: [String: ResponseValue]()) { $0[$1.key.rawValue] = $1.value }
     }
 }
 
 public extension JSONDecoder {
+    /// Helper which deserializes a `Responses.encodableDictionary`.
     func decodeResponses(from data: Data) throws -> Responses {
         let dictionary = try decode([String: ResponseValue].self, from: data)
-        return dictionary.reduce([Reference: ResponseValue]()) { partialResult, pair in
-            var result = partialResult
-            result[Reference.make(with: pair.key)] = pair.value
-            return result
-        }
+        return dictionary.reduce(into: [Reference: ResponseValue]()) { $0[Reference.make(with: $1.key)] = $1.value }
     }
 }

--- a/Sources/Typeform/Models/Upload.swift
+++ b/Sources/Typeform/Models/Upload.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-public struct Upload: Hashable {
+public struct Upload: Hashable, Codable, Sendable {
 
-    public enum Path: String, Hashable, Identifiable {
+    public enum Path: String, Hashable, Identifiable, Codable, Sendable {
         case camera
         case photoLibrary
         case documents

--- a/Sources/Typeform/Schema/Action.swift
+++ b/Sources/Typeform/Schema/Action.swift
@@ -1,25 +1,25 @@
 import Foundation
 
-public struct Action: Hashable, Codable {
+public struct Action: Hashable, Codable, Sendable {
 
-    public enum Kind: String, Codable {
+    public enum Kind: String, Codable, Sendable {
         case jump
     }
 
-    public struct Details: Hashable, Codable {
+    public struct Details: Hashable, Codable, Sendable {
 
-        public enum ToType: String, Codable {
+        public enum ToType: String, Codable, Sendable {
             case field
             case ending = "thankyou"
         }
 
-        public struct To: Hashable, Codable {
+        public struct To: Hashable, Codable, Sendable {
             public let type: ToType
             public let value: Reference
 
             public init(
                 type: ToType = .field,
-                value: Reference = Reference()
+                value: Reference = ""
             ) {
                 self.type = type
                 self.value = value

--- a/Sources/Typeform/Schema/Choice.swift
+++ b/Sources/Typeform/Schema/Choice.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-public struct Choice: Hashable, Identifiable, Codable {
+public struct Choice: Hashable, Identifiable, Codable, Sendable {
     public let id: String
     public let ref: Reference
     public let label: String
 
     public init(
         id: String = "",
-        ref: Reference = Reference(),
+        ref: Reference = "",
         label: String = ""
     ) {
         self.id = id

--- a/Sources/Typeform/Schema/Condition.swift
+++ b/Sources/Typeform/Schema/Condition.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-public struct Condition: Hashable, Codable {
+public struct Condition: Hashable, Codable, Sendable {
 
-    public enum Parameters: Hashable {
+    public enum Parameters: Hashable, Sendable {
         case vars([Var])
         case conditions([Condition])
     }

--- a/Sources/Typeform/Schema/Field.swift
+++ b/Sources/Typeform/Schema/Field.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-public struct Field: Hashable, Identifiable, Codable {
+public struct Field: Hashable, Identifiable, Codable, Sendable {
 
-    public enum Kind: String, Codable {
+    public enum Kind: String, Codable, Sendable {
         case date
         case dropdown
         case fileUpload = "file_upload"
@@ -17,7 +17,7 @@ public struct Field: Hashable, Identifiable, Codable {
         case yesNo = "yes_no"
     }
 
-    public enum Properties: Hashable, Codable {
+    public enum Properties: Hashable, Codable, Sendable {
         case date(DateStamp)
         case dropdown(Dropdown)
         case fileUpload(FileUpload)
@@ -69,7 +69,7 @@ public struct Field: Hashable, Identifiable, Codable {
 
     public init(
         id: String = "",
-        ref: Reference = Reference(),
+        ref: Reference = "",
         type: Kind = .yesNo,
         title: String = "",
         properties: Properties = .yesNo(YesNo()),

--- a/Sources/Typeform/Schema/Form.swift
+++ b/Sources/Typeform/Schema/Form.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-public struct Form: Hashable, Identifiable, Codable {
+public struct Form: Hashable, Identifiable, Codable, Sendable {
 
-    public enum Kind: String, Codable {
+    public enum Kind: String, Codable, Sendable {
         case quiz
     }
 

--- a/Sources/Typeform/Schema/Links.swift
+++ b/Sources/Typeform/Schema/Links.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct Links: Hashable, Codable {
+public struct Links: Hashable, Codable, Sendable {
     public let display: URL
 
     public init(

--- a/Sources/Typeform/Schema/Logic.swift
+++ b/Sources/Typeform/Schema/Logic.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-public struct Logic: Hashable, Codable {
+public struct Logic: Hashable, Codable, Sendable {
 
-    public enum Kind: String, Codable {
+    public enum Kind: String, Codable, Sendable {
         case field
     }
 

--- a/Sources/Typeform/Schema/Op.swift
+++ b/Sources/Typeform/Schema/Op.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum Op: String, Codable {
+public enum Op: String, Codable, Sendable {
     case always
     case and
     case beginsWith = "begins_with"

--- a/Sources/Typeform/Schema/Questions/DateStamp.swift
+++ b/Sources/Typeform/Schema/Questions/DateStamp.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct DateStamp: Hashable, Codable {
+public struct DateStamp: Hashable, Codable, Sendable {
     public let separator: String
     public let structure: String
     public let description: String?

--- a/Sources/Typeform/Schema/Questions/Dropdown.swift
+++ b/Sources/Typeform/Schema/Questions/Dropdown.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct Dropdown: Hashable, Codable {
+public struct Dropdown: Hashable, Codable, Sendable {
     public let choices: [Choice]
     public let description: String?
     public let randomize: Bool

--- a/Sources/Typeform/Schema/Questions/FileUpload.swift
+++ b/Sources/Typeform/Schema/Questions/FileUpload.swift
@@ -1,4 +1,4 @@
-public struct FileUpload: Hashable, Codable {
+public struct FileUpload: Hashable, Codable, Sendable {
     public let description: String?
 
     public init(description: String?) {

--- a/Sources/Typeform/Schema/Questions/LongText.swift
+++ b/Sources/Typeform/Schema/Questions/LongText.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct LongText: Hashable, Codable {
+public struct LongText: Hashable, Codable, Sendable {
     public let description: String?
 
     public init(

--- a/Sources/Typeform/Schema/Questions/MultipleChoice.swift
+++ b/Sources/Typeform/Schema/Questions/MultipleChoice.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct MultipleChoice: Hashable, Codable {
+public struct MultipleChoice: Hashable, Codable, Sendable {
     public let choices: [Choice]
     public let randomize: Bool
     public let allow_multiple_selection: Bool

--- a/Sources/Typeform/Schema/Questions/Number.swift
+++ b/Sources/Typeform/Schema/Questions/Number.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct Number: Hashable, Codable {
+public struct Number: Hashable, Codable, Sendable {
     public let description: String?
 
     public init(

--- a/Sources/Typeform/Schema/Questions/OpinionScale.swift
+++ b/Sources/Typeform/Schema/Questions/OpinionScale.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-public struct OpinionScale: Hashable, Codable {
+public struct OpinionScale: Hashable, Codable, Sendable {
 
-    public struct Labels: Hashable, Codable {
+    public struct Labels: Hashable, Codable, Sendable {
 
         enum CodingKeys: String, CodingKey {
             case leading = "left"

--- a/Sources/Typeform/Schema/Questions/Rating.swift
+++ b/Sources/Typeform/Schema/Questions/Rating.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct Rating: Hashable, Codable {
+public struct Rating: Hashable, Codable, Sendable {
     public let shape: String
     public let steps: Int
     public let description: String?

--- a/Sources/Typeform/Schema/Questions/ShortText.swift
+++ b/Sources/Typeform/Schema/Questions/ShortText.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct ShortText: Hashable, Codable {
+public struct ShortText: Hashable, Codable, Sendable {
     public let description: String?
 
     public init(

--- a/Sources/Typeform/Schema/Questions/YesNo.swift
+++ b/Sources/Typeform/Schema/Questions/YesNo.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct YesNo: Hashable, Codable {
+public struct YesNo: Hashable, Codable, Sendable {
 
     public let description: String?
 

--- a/Sources/Typeform/Schema/Settings.swift
+++ b/Sources/Typeform/Schema/Settings.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-public struct Settings: Hashable, Codable {
+public struct Settings: Hashable, Codable, Sendable {
 
-    public struct Meta: Hashable, Codable {
+    public struct Meta: Hashable, Codable, Sendable {
         public let allow_indexing: Bool
 
         public init(allow_indexing: Bool = false) {
@@ -10,9 +10,9 @@ public struct Settings: Hashable, Codable {
         }
     }
 
-    public struct Capabilities: Hashable, Codable {
+    public struct Capabilities: Hashable, Codable, Sendable {
 
-        public struct EndToEndEncryption: Hashable, Codable {
+        public struct EndToEndEncryption: Hashable, Codable, Sendable {
             public let enabled: Bool
             public let modifiable: Bool
 

--- a/Sources/Typeform/Schema/Structure/Attachment.swift
+++ b/Sources/Typeform/Schema/Structure/Attachment.swift
@@ -3,14 +3,14 @@ import Foundation
 @available(*, deprecated, renamed: "Attachment")
 public typealias ScreenAttachment = Attachment
 
-public struct Attachment: Hashable, Codable {
+public struct Attachment: Hashable, Codable, Sendable {
 
-    public enum Kind: String, Codable {
+    public enum Kind: String, Codable, Sendable {
         case image
         case video
     }
 
-    public struct Properties: Hashable, Codable {
+    public struct Properties: Hashable, Codable, Sendable {
         public let description: String?
 
         public init(description: String? = nil) {

--- a/Sources/Typeform/Schema/Structure/EndingScreen.swift
+++ b/Sources/Typeform/Schema/Structure/EndingScreen.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-public struct EndingScreen: Screen, Hashable, Codable {
+public struct EndingScreen: Screen, Hashable, Codable, Sendable {
 
-    public enum Ref: Hashable, Codable {
+    public enum Ref: Hashable, Codable, Sendable {
         case `default`
         case ref(Reference)
 

--- a/Sources/Typeform/Schema/Structure/Group.swift
+++ b/Sources/Typeform/Schema/Structure/Group.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct Group: Hashable, Codable {
+public struct Group: Hashable, Codable, Sendable {
     public let button_text: String
     public let fields: [Field]
     public let show_button: Bool

--- a/Sources/Typeform/Schema/Structure/ScreenProperties.swift
+++ b/Sources/Typeform/Schema/Structure/ScreenProperties.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct ScreenProperties: Hashable, Codable {
+public struct ScreenProperties: Hashable, Codable, Sendable {
     public let button_mode: String?
     public let button_text: String?
     public let share_icons: Bool?

--- a/Sources/Typeform/Schema/Structure/Statement.swift
+++ b/Sources/Typeform/Schema/Structure/Statement.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct Statement: Hashable, Codable {
+public struct Statement: Hashable, Codable, Sendable {
     public let hide_marks: Bool
     public let button_text: String
     public let description: String?

--- a/Sources/Typeform/Schema/Structure/WelcomeScreen.swift
+++ b/Sources/Typeform/Schema/Structure/WelcomeScreen.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct WelcomeScreen: Screen, Hashable, Codable {
+public struct WelcomeScreen: Screen, Hashable, Codable, Sendable {
     public let id: String
     public let ref: Reference
     public let title: String
@@ -9,7 +9,7 @@ public struct WelcomeScreen: Screen, Hashable, Codable {
 
     public init(
         id: String = "",
-        ref: Reference = Reference(),
+        ref: Reference = "",
         title: String = "",
         attachment: Attachment? = nil,
         properties: ScreenProperties = ScreenProperties()

--- a/Sources/Typeform/Schema/Theme.swift
+++ b/Sources/Typeform/Schema/Theme.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct Theme: Hashable, Codable {
+public struct Theme: Hashable, Codable, Sendable {
     public let href: URL
 
     public init(

--- a/Sources/Typeform/Schema/Validations.swift
+++ b/Sources/Typeform/Schema/Validations.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct Validations: Hashable, Codable {
+public struct Validations: Hashable, Codable, Sendable {
     public let required: Bool
 
     public init(

--- a/Sources/Typeform/Schema/Var.swift
+++ b/Sources/Typeform/Schema/Var.swift
@@ -1,14 +1,14 @@
 import Foundation
 
-public struct Var: Hashable, Codable {
+public struct Var: Hashable, Codable, Sendable {
 
-    public enum VarType: String, Codable {
+    public enum VarType: String, Codable, Sendable {
         case choice
         case constant
         case field
     }
 
-    public enum Value: Hashable, Codable {
+    public enum Value: Hashable, Codable, Sendable {
         case bool(Bool)
         case ref(Reference)
         case string(String)

--- a/Sources/Typeform/Schema/Workspace.swift
+++ b/Sources/Typeform/Schema/Workspace.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct Workspace: Hashable, Codable {
+public struct Workspace: Hashable, Codable, Sendable {
     public let href: URL
 
     public init(


### PR DESCRIPTION
# Description

Add `Codable` support to `ResponseValue`

## New/Updated Features

This enables a _out-of-the-box_ implementation to serialize and deserialize a Form response collection. The response dictionary (`[Reference: ResponseValue]`) is first converted to `[String: ResponseValue]`, which produces the expected JSON dictionary format. Response Values are individually converted to an object with a single key indicating its data type. For instance:

```swift
let collection: [Reference: ResponseValue] = [
  .string("name"): .string("Bob"),
  .string("age"): .int(42),
]
```

will be serialized as

```json
{
  "name": {
    "string": "Bob"
  },
  "age": {
    "int": 42
  }
}
```

This avoids the topic of attempting to de/serialize an untyped dictionary ([String: Any]).

This implementation is consistent with changes to the Kotlin library: https://github.com/Nice-Healthcare/typeform-kotlin/pull/21

---

Note: Any implementation (such as our internal use) can override this _default_ serialization; but this provides a potential solution for those wanting to persist or transfer a response collection.
