### PR TITLE
Liquid Glass

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -11,6 +11,7 @@
 --disable blankLinesAtStartOfScope
 --disable hoistPatternLet
 --disable redundantType
+--disable swiftTestingTestCaseNames
 --disable unusedArguments
 --disable wrapArguments
 --disable wrapPropertyBodies

--- a/Sources/TypeformUI/Structure/FieldView.swift
+++ b/Sources/TypeformUI/Structure/FieldView.swift
@@ -195,7 +195,7 @@ struct FieldView<Header: View, Footer: View>: View {
         }
         .toolbar {
             ToolbarItemGroup(placement: .primaryAction) {
-                Button(role: .destructive) {
+                Button {
                     focused = false
                     if settings.presentation.skipWelcomeScreen, responses.isEmpty {
                         conclusion(.canceled)

--- a/Sources/TypeformUI/Structure/FieldView.swift
+++ b/Sources/TypeformUI/Structure/FieldView.swift
@@ -185,46 +185,48 @@ struct FieldView<Header: View, Footer: View>: View {
             )
         }
         .background(settings.presentation.backgroundColor)
-        .scrollDismissesKeyboard(.immediately)
-        .onAppear {
-            determineNext()
-        }
-        .onChange(of: responseState) { newValue in
-            responses[field.ref] = newValue.response
-            determineNext()
-        }
-        .toolbar {
-            ToolbarItemGroup(placement: .primaryAction) {
-                Button {
-                    focused = false
-                    if settings.presentation.skipWelcomeScreen, responses.isEmpty {
-                        conclusion(.canceled)
-                    } else {
-                        cancel = true
+        #if !os(tvOS)
+            .scrollDismissesKeyboard(.immediately)
+        #endif
+            .onAppear {
+                determineNext()
+            }
+            .onChange(of: responseState) { newValue in
+                responses[field.ref] = newValue.response
+                determineNext()
+            }
+            .toolbar {
+                ToolbarItemGroup(placement: .primaryAction) {
+                    Button {
+                        focused = false
+                        if settings.presentation.skipWelcomeScreen, responses.isEmpty {
+                            conclusion(.canceled)
+                        } else {
+                            cancel = true
+                        }
+                    } label: {
+                        Label(settings.localization.exit, systemImage: "xmark")
                     }
-                } label: {
-                    Label(settings.localization.exit, systemImage: "xmark")
-                }
-                .buttonStyle(.borderless)
+                    .buttonStyle(.borderless)
 
-                if settings.presentation.layout == .navigation {
-                    navigation(next: next)
-                        .buttonStyle(.borderless)
+                    if settings.presentation.layout == .navigation {
+                        navigation(next: next)
+                            .buttonStyle(.borderless)
+                    }
                 }
             }
-        }
-        .alert(settings.localization.abandonConfirmationTitle, isPresented: $cancel) {
-            Button(settings.localization.cancel, role: .cancel) {
-                cancel = false
-            }
+            .alert(settings.localization.abandonConfirmationTitle, isPresented: $cancel) {
+                Button(settings.localization.cancel, role: .cancel) {
+                    cancel = false
+                }
 
-            Button(settings.localization.abandonConfirmationAction, role: .destructive) {
-                cancel = false
-                conclusion(.abandoned(responses))
+                Button(settings.localization.abandonConfirmationAction, role: .destructive) {
+                    cancel = false
+                    conclusion(.abandoned(responses))
+                }
+            } message: {
+                Text(settings.localization.abandonConfirmationMessage)
             }
-        } message: {
-            Text(settings.localization.abandonConfirmationMessage)
-        }
     }
 
     private func determineNext() {

--- a/Sources/TypeformUI/Structure/FieldView.swift
+++ b/Sources/TypeformUI/Structure/FieldView.swift
@@ -185,6 +185,7 @@ struct FieldView<Header: View, Footer: View>: View {
             )
         }
         .background(settings.presentation.backgroundColor)
+        .scrollDismissesKeyboard(.immediately)
         .onAppear {
             determineNext()
         }
@@ -194,7 +195,7 @@ struct FieldView<Header: View, Footer: View>: View {
         }
         .toolbar {
             ToolbarItemGroup(placement: .primaryAction) {
-                Button {
+                Button(role: .destructive) {
                     focused = false
                     if settings.presentation.skipWelcomeScreen, responses.isEmpty {
                         conclusion(.canceled)
@@ -202,13 +203,11 @@ struct FieldView<Header: View, Footer: View>: View {
                         cancel = true
                     }
                 } label: {
-                    Text(settings.localization.exit)
+                    Label(settings.localization.exit, systemImage: "xmark")
                 }
-                .buttonStyle(.borderless)
 
                 if settings.presentation.layout == .navigation {
                     navigation(next: next)
-                        .buttonStyle(.borderless)
                 }
             }
         }

--- a/Sources/TypeformUI/Structure/FieldView.swift
+++ b/Sources/TypeformUI/Structure/FieldView.swift
@@ -205,9 +205,11 @@ struct FieldView<Header: View, Footer: View>: View {
                 } label: {
                     Label(settings.localization.exit, systemImage: "xmark")
                 }
+                .buttonStyle(.borderless)
 
                 if settings.presentation.layout == .navigation {
                     navigation(next: next)
+                        .buttonStyle(.borderless)
                 }
             }
         }

--- a/Sources/TypeformUI/Structure/FieldView.swift
+++ b/Sources/TypeformUI/Structure/FieldView.swift
@@ -185,7 +185,7 @@ struct FieldView<Header: View, Footer: View>: View {
             )
         }
         .background(settings.presentation.backgroundColor)
-        #if !os(tvOS)
+        #if !os(tvOS) && !os(visionOS)
             .scrollDismissesKeyboard(.immediately)
         #endif
             .onAppear {

--- a/Sources/TypeformUI/Structure/RejectedView.swift
+++ b/Sources/TypeformUI/Structure/RejectedView.swift
@@ -49,12 +49,12 @@ struct RejectedView: View {
         }
         .background(settings.presentation.backgroundColor)
         .toolbar {
-            ToolbarItemGroup(placement: .primaryAction) {
+            ToolbarItemGroup(placement: .confirmationAction) {
                 if settings.presentation.layout == .navigation {
                     Button {
                         conclusion(.rejected(responses))
                     } label: {
-                        Text(settings.localization.finish)
+                        Label(settings.localization.finish, systemImage: "checkmark")
                     }
                 }
             }

--- a/Sources/TypeformUI/Structure/ScreenView.swift
+++ b/Sources/TypeformUI/Structure/ScreenView.swift
@@ -111,11 +111,13 @@ struct ScreenView<Header: View, Footer: View>: View {
                         } label: {
                             Label(settings.localization.exit, systemImage: "xmark")
                         }
+                        .buttonStyle(.borderless)
                     }
 
                     if settings.presentation.layout == .navigation {
                         if let next {
                             navigation(next: next)
+                                .buttonStyle(.borderless)
                         }
 
                         if !isWelcome {

--- a/Sources/TypeformUI/Structure/ScreenView.swift
+++ b/Sources/TypeformUI/Structure/ScreenView.swift
@@ -106,7 +106,7 @@ struct ScreenView<Header: View, Footer: View>: View {
             .toolbar {
                 ToolbarItemGroup(placement: .topBarTrailing) {
                     if isWelcome {
-                        Button(role: .destructive) {
+                        Button {
                             conclusion(.canceled)
                         } label: {
                             Label(settings.localization.exit, systemImage: "xmark")

--- a/Sources/TypeformUI/Structure/ScreenView.swift
+++ b/Sources/TypeformUI/Structure/ScreenView.swift
@@ -104,27 +104,25 @@ struct ScreenView<Header: View, Footer: View>: View {
                 }
             }
             .toolbar {
-                ToolbarItemGroup(placement: .primaryAction) {
+                ToolbarItemGroup(placement: .topBarTrailing) {
                     if isWelcome {
-                        Button {
+                        Button(role: .destructive) {
                             conclusion(.canceled)
                         } label: {
-                            Text(settings.localization.exit)
+                            Label(settings.localization.exit, systemImage: "xmark")
                         }
-                        .buttonStyle(.borderless)
                     }
 
                     if settings.presentation.layout == .navigation {
                         if let next {
                             navigation(next: next)
-                                .buttonStyle(.borderless)
                         }
 
                         if !isWelcome {
                             Button {
                                 conclusion(.completed(responses, screen as! EndingScreen))
                             } label: {
-                                Text(settings.localization.finish)
+                                Label(settings.localization.finish, systemImage: "checkmark")
                             }
                         }
                     }

--- a/Sources/TypeformUI/Structure/ScreenView.swift
+++ b/Sources/TypeformUI/Structure/ScreenView.swift
@@ -104,7 +104,7 @@ struct ScreenView<Header: View, Footer: View>: View {
                 }
             }
             .toolbar {
-                ToolbarItemGroup(placement: .topBarTrailing) {
+                ToolbarItemGroup(placement: .primaryAction) {
                     if isWelcome {
                         Button {
                             conclusion(.canceled)


### PR DESCRIPTION
# Description

A few minor updates to integrate better on iOS 26 platform and the 'Liquid Glass' design. Adds symbols to navigation toolbar items, plus adds the `.scrollDismissesKeyboard(.immediately)` modifier to automatically dismiss the keyboard when views scroll.

Internal reference: PATM-1423
